### PR TITLE
Subissue 1.1 – FR2 Command Control for Erasing (#51)

### DIFF
--- a/src/hooks/useWhiteboardSimulation.ts
+++ b/src/hooks/useWhiteboardSimulation.ts
@@ -15,6 +15,9 @@ import { toast } from "sonner";
 import {
   COUNTDOWN_SECONDS,
   applyEraseToCanvas,
+  canPause,
+  canStart,
+  canStop,
   computeEraseProgressTick,
   createSnapshotNote,
   createSystemLog,
@@ -148,10 +151,10 @@ export const useWhiteboardSimulation = () => {
   }, [addLog, completeErase]);
 
   const startErase = useCallback(() => {
-    if (status !== "idle" && status !== "completed" && status !== "paused") {
-      const reason = `Start is unavailable while status is '${status}'`;
-      auditCommand("start", false, reason);
-      addLog("warning", `FR2: ${reason}`);
+    const guard = canStart(status);
+    if (!guard.allowed) {
+      auditCommand("start", false, guard.rejection.message);
+      addLog("warning", `FR2: ${guard.rejection.message}`);
       toast.info("Start unavailable in current state");
       return;
     }
@@ -181,10 +184,10 @@ export const useWhiteboardSimulation = () => {
   }, [addLog]);
 
   const pauseErase = useCallback(() => {
-    if (status !== "erasing") {
-      const reason = `Pause is unavailable while status is '${status}'`;
-      auditCommand("pause", false, reason);
-      addLog("warning", `FR2: ${reason}`);
+    const guard = canPause(status);
+    if (!guard.allowed) {
+      auditCommand("pause", false, guard.rejection.message);
+      addLog("warning", `FR2: ${guard.rejection.message}`);
       toast.info("Pause unavailable in current state");
       return;
     }
@@ -202,15 +205,10 @@ export const useWhiteboardSimulation = () => {
   }, [status, addLog, auditCommand]);
 
   const stopErase = useCallback(() => {
-    const canStop =
-      status === "erasing" ||
-      status === "countdown" ||
-      status === "paused" ||
-      status === "obstacle-detected";
-    if (!canStop) {
-      const reason = `Stop is unavailable while status is '${status}'`;
-      auditCommand("stop", false, reason);
-      addLog("warning", `FR2: ${reason}`);
+    const guard = canStop(status);
+    if (!guard.allowed) {
+      auditCommand("stop", false, guard.rejection.message);
+      addLog("warning", `FR2: ${guard.rejection.message}`);
       toast.info("Stop unavailable in current state");
       return;
     }

--- a/src/simulation/commandGuards.ts
+++ b/src/simulation/commandGuards.ts
@@ -1,0 +1,80 @@
+import type { CommandAction, SystemStatus } from "@/types/whiteboard";
+
+/**
+ * FR2 command control — pure, side-effect free guards for start / pause / stop
+ * commands operating on the automatic full-erase pipeline (F1: "automatic full erase
+ * at the press of a button"). Used by the React bridge (`useWhiteboardSimulation`)
+ * and by any future non-UI caller (e.g. teacher voice command, scheduled task).
+ *
+ * Design (Subissue 1.1 / #51):
+ *   - Guards are pure functions of `SystemStatus`; no React, no toasts, no timers.
+ *   - Rejections carry a typed `reason` code so audit logs / tests / UI can all
+ *     distinguish cases without string matching.
+ *   - `canStart` covers both "begin from idle/completed" and "resume from paused".
+ */
+
+export type CommandRejectionCode =
+  | "invalid_state"
+  | "already_running"
+  | "nothing_to_pause"
+  | "nothing_to_stop";
+
+export interface CommandRejection {
+  code: CommandRejectionCode;
+  message: string;
+  status: SystemStatus;
+}
+
+export type CommandGuardResult =
+  | { allowed: true }
+  | { allowed: false; rejection: CommandRejection };
+
+const deny = (
+  code: CommandRejectionCode,
+  status: SystemStatus,
+  message: string,
+): CommandGuardResult => ({ allowed: false, rejection: { code, status, message } });
+
+export function canStart(status: SystemStatus): CommandGuardResult {
+  if (status === "idle" || status === "completed" || status === "paused") {
+    return { allowed: true };
+  }
+  if (status === "erasing" || status === "countdown") {
+    return deny("already_running", status, `Start ignored — erase is already ${status}.`);
+  }
+  return deny(
+    "invalid_state",
+    status,
+    `Start is unavailable while status is '${status}'.`,
+  );
+}
+
+export function canPause(status: SystemStatus): CommandGuardResult {
+  if (status === "erasing") return { allowed: true };
+  return deny(
+    status === "idle" || status === "completed" ? "nothing_to_pause" : "invalid_state",
+    status,
+    `Pause is unavailable while status is '${status}'.`,
+  );
+}
+
+export function canStop(status: SystemStatus): CommandGuardResult {
+  const stoppable: SystemStatus[] = ["erasing", "countdown", "paused", "obstacle-detected"];
+  if (stoppable.includes(status)) return { allowed: true };
+  return deny("nothing_to_stop", status, `Stop is unavailable while status is '${status}'.`);
+}
+
+/** Dispatch helper: pick the guard matching a `CommandAction`. */
+export function evaluateCommand(
+  action: CommandAction,
+  status: SystemStatus,
+): CommandGuardResult {
+  switch (action) {
+    case "start":
+      return canStart(status);
+    case "pause":
+      return canPause(status);
+    case "stop":
+      return canStop(status);
+  }
+}

--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -10,3 +10,14 @@ export { computeEraseProgressTick } from "./eraseProgress";
 export type { EraseProgressTick } from "./eraseProgress";
 export { proximityWhenClear, proximityWhenObstacleDetected } from "./proximityState";
 export { createSnapshotNote, createSystemLog } from "./snapshotAndLog";
+export {
+  canPause,
+  canStart,
+  canStop,
+  evaluateCommand,
+} from "./commandGuards";
+export type {
+  CommandGuardResult,
+  CommandRejection,
+  CommandRejectionCode,
+} from "./commandGuards";


### PR DESCRIPTION
Closes #51. Closes #185. Closes #186. Closes #187. Closes #188. Closes #189.

## Summary

Decomposes **FR2 command-control** validation for the **F1 automatic full-erase at the press of a button** pipeline (parent #39) into a pure, reusable module. React and any future non-UI caller (robot script, scheduled task) share the same invariants.

## Changes

- **`src/simulation/commandGuards.ts`** (new): `canStart`, `canPause`, `canStop` as pure functions of `SystemStatus` and an `evaluateCommand(action, status)` dispatcher. Typed `CommandRejectionCode` union replaces free-form reason strings: `invalid_state | already_running | nothing_to_pause | nothing_to_stop`.
- **`src/simulation/index.ts`**: re-export guards + `CommandGuardResult` / `CommandRejection` types.
- **`src/hooks/useWhiteboardSimulation.ts`**: `startErase` / `pauseErase` / `stopErase` delegate to the new guards; `auditCommand`, `addLog('warning', 'FR2: ...')`, and `toast.info` behavior preserved.

## Sub-task decomposition (traceability)

- 1.1.1 (#185) Extract command guards
- 1.1.2 (#186) Typed rejection codes
- 1.1.3 (#187) Centralize FR2 audit pipeline
- 1.1.4 (#188) `evaluateCommand` dispatcher for non-UI callers
- 1.1.5 (#189) JSDoc on command-control lifecycle

## Verification

- `npx tsc --noEmit` clean.
- `npm run build` succeeds (no new warnings).
- `npm run lint` produces only pre-existing warnings in `src/components/ui/*` (shadcn files), none in changed files.
- Manual: `npm run dev` Start / Pause / Stop paths exercise each guard branch; rejected commands produce the same UX as before.
