### PR TITLE
Subissue 2.1 – FR2 Command Control for Section Erase (#56)

### DIFF
--- a/src/hooks/useWhiteboardSimulation.ts
+++ b/src/hooks/useWhiteboardSimulation.ts
@@ -151,11 +151,21 @@ export const useWhiteboardSimulation = () => {
   }, [addLog, completeErase]);
 
   const startErase = useCallback(() => {
-    const guard = canStart(status);
+    const canvas = fabricCanvasRef.current;
+    const canvasBounds =
+      canvas != null
+        ? { width: canvas.getWidth(), height: canvas.getHeight() }
+        : undefined;
+    const guard = canStart(status, { eraseMode, partialArea, canvasBounds });
     if (!guard.allowed) {
       auditCommand("start", false, guard.rejection.message);
       addLog("warning", `FR2: ${guard.rejection.message}`);
-      toast.info("Start unavailable in current state");
+      const { code } = guard.rejection;
+      if (code === "no_section_selected" || code === "invalid_section_bounds") {
+        toast.info("Select an area to erase before starting");
+      } else {
+        toast.info("Start unavailable in current state");
+      }
       return;
     }
     auditCommand("start", true);
@@ -170,7 +180,7 @@ export const useWhiteboardSimulation = () => {
     saveSnapshot();
     setStatus("countdown");
     addLog("info", "Countdown started (10 seconds warning)");
-  }, [status, saveSnapshot, simulateErase, addLog, auditCommand]);
+  }, [status, eraseMode, partialArea, saveSnapshot, simulateErase, addLog, auditCommand]);
 
   const onCountdownComplete = useCallback(() => {
     setStatus("erasing");

--- a/src/simulation/commandGuards.ts
+++ b/src/simulation/commandGuards.ts
@@ -1,23 +1,52 @@
-import type { CommandAction, SystemStatus } from "@/types/whiteboard";
+import type {
+  CommandAction,
+  EraseArea,
+  EraseMode,
+  SystemStatus,
+} from "@/types/whiteboard";
+import {
+  validateEraseArea,
+  type CanvasBounds,
+  type EraseAreaInvalidReason,
+} from "./validateEraseArea";
 
 /**
  * FR2 command control — pure, side-effect free guards for start / pause / stop
- * commands operating on the automatic full-erase pipeline (F1: "automatic full erase
- * at the press of a button"). Used by the React bridge (`useWhiteboardSimulation`)
- * and by any future non-UI caller (e.g. teacher voice command, scheduled task).
+ * commands covering both erase pipelines:
  *
- * Design (Subissue 1.1 / #51):
- *   - Guards are pure functions of `SystemStatus`; no React, no toasts, no timers.
- *   - Rejections carry a typed `reason` code so audit logs / tests / UI can all
- *     distinguish cases without string matching.
- *   - `canStart` covers both "begin from idle/completed" and "resume from paused".
+ *   - F1 (#39) "automatic full erase at the press of a button"
+ *   - F2 (#40) "select specific sections to erase"
+ *
+ * Used by the React bridge (`useWhiteboardSimulation`) and by any future
+ * non-UI caller (teacher voice command, scheduled task, robot CLI).
+ *
+ * Design:
+ *   - Guards are pure functions; no React, no toasts, no timers.
+ *   - Rejections carry a typed `code` so audit logs / tests / UI can branch
+ *     without string matching.
+ *   - F2 callers pass an optional `CommandContext` describing the current
+ *     erase mode and selected region. When `eraseMode === "partial"`, Start
+ *     requires a valid `EraseArea` (non-null, positive dims, in-bounds).
+ *   - F1 callers may omit the context entirely; full-erase semantics apply.
+ *
+ * Rejection codes:
+ *   - `invalid_state`          — command invalid for current `SystemStatus`.
+ *   - `already_running`        — Start while `erasing` / `countdown`.
+ *   - `nothing_to_pause`       — Pause while `idle` / `completed`.
+ *   - `nothing_to_stop`        — Stop while no operation is interruptible.
+ *   - `no_section_selected`    — F2: Start pressed in partial mode with no
+ *                                selection.
+ *   - `invalid_section_bounds` — F2: selected rectangle has non-positive
+ *                                dimensions or lies outside the canvas.
  */
 
 export type CommandRejectionCode =
   | "invalid_state"
   | "already_running"
   | "nothing_to_pause"
-  | "nothing_to_stop";
+  | "nothing_to_stop"
+  | "no_section_selected"
+  | "invalid_section_bounds";
 
 export interface CommandRejection {
   code: CommandRejectionCode;
@@ -29,24 +58,57 @@ export type CommandGuardResult =
   | { allowed: true }
   | { allowed: false; rejection: CommandRejection };
 
+export interface CommandContext {
+  eraseMode?: EraseMode;
+  partialArea?: EraseArea | null;
+  canvasBounds?: CanvasBounds;
+}
+
 const deny = (
   code: CommandRejectionCode,
   status: SystemStatus,
   message: string,
 ): CommandGuardResult => ({ allowed: false, rejection: { code, status, message } });
 
-export function canStart(status: SystemStatus): CommandGuardResult {
-  if (status === "idle" || status === "completed" || status === "paused") {
-    return { allowed: true };
+const sectionRejection = (
+  status: SystemStatus,
+  reason: EraseAreaInvalidReason,
+): CommandGuardResult => {
+  if (reason === "missing") {
+    return deny(
+      "no_section_selected",
+      status,
+      "Start ignored — select an area on the whiteboard before starting a partial erase.",
+    );
   }
+  return deny(
+    "invalid_section_bounds",
+    status,
+    `Start ignored — selected section is invalid (${reason.replace(/_/g, " ")}).`,
+  );
+};
+
+export function canStart(
+  status: SystemStatus,
+  context: CommandContext = {},
+): CommandGuardResult {
   if (status === "erasing" || status === "countdown") {
     return deny("already_running", status, `Start ignored — erase is already ${status}.`);
   }
-  return deny(
-    "invalid_state",
-    status,
-    `Start is unavailable while status is '${status}'.`,
-  );
+  if (status !== "idle" && status !== "completed" && status !== "paused") {
+    return deny(
+      "invalid_state",
+      status,
+      `Start is unavailable while status is '${status}'.`,
+    );
+  }
+
+  if (context.eraseMode === "partial" && status !== "paused") {
+    const check = validateEraseArea(context.partialArea, context.canvasBounds);
+    if (!check.valid) return sectionRejection(status, check.reason);
+  }
+
+  return { allowed: true };
 }
 
 export function canPause(status: SystemStatus): CommandGuardResult {
@@ -68,10 +130,11 @@ export function canStop(status: SystemStatus): CommandGuardResult {
 export function evaluateCommand(
   action: CommandAction,
   status: SystemStatus,
+  context: CommandContext = {},
 ): CommandGuardResult {
   switch (action) {
     case "start":
-      return canStart(status);
+      return canStart(status, context);
     case "pause":
       return canPause(status);
     case "stop":

--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -17,7 +17,14 @@ export {
   evaluateCommand,
 } from "./commandGuards";
 export type {
+  CommandContext,
   CommandGuardResult,
   CommandRejection,
   CommandRejectionCode,
 } from "./commandGuards";
+export { validateEraseArea } from "./validateEraseArea";
+export type {
+  CanvasBounds,
+  EraseAreaInvalidReason,
+  EraseAreaValidation,
+} from "./validateEraseArea";

--- a/src/simulation/validateEraseArea.ts
+++ b/src/simulation/validateEraseArea.ts
@@ -1,0 +1,60 @@
+import type { EraseArea } from "@/types/whiteboard";
+
+/**
+ * Section-erase (F2) geometry validator.
+ *
+ * Pure, side-effect free. Returns a discriminated union so callers can switch
+ * on the concrete failure reason without string matching. Used by FR2 command
+ * guards to reject Start when the selected region is missing or malformed.
+ *
+ * `canvasBounds` is optional: if supplied, the selection must lie fully
+ * within `[0, width] x [0, height]`. When omitted, only intrinsic checks
+ * (non-null, positive dimensions, finite numbers) are performed.
+ */
+
+export type EraseAreaInvalidReason =
+  | "missing"
+  | "non_positive_dimensions"
+  | "non_finite_coordinates"
+  | "out_of_bounds";
+
+export type EraseAreaValidation =
+  | { valid: true; area: EraseArea }
+  | { valid: false; reason: EraseAreaInvalidReason };
+
+export interface CanvasBounds {
+  width: number;
+  height: number;
+}
+
+const isFiniteNumber = (n: number): boolean => Number.isFinite(n);
+
+export function validateEraseArea(
+  area: EraseArea | null | undefined,
+  canvasBounds?: CanvasBounds,
+): EraseAreaValidation {
+  if (!area) return { valid: false, reason: "missing" };
+
+  const { x, y, width, height } = area;
+
+  if (![x, y, width, height].every(isFiniteNumber)) {
+    return { valid: false, reason: "non_finite_coordinates" };
+  }
+
+  if (width <= 0 || height <= 0) {
+    return { valid: false, reason: "non_positive_dimensions" };
+  }
+
+  if (canvasBounds) {
+    const { width: cw, height: ch } = canvasBounds;
+    const leftInside = x >= 0 && x <= cw;
+    const topInside = y >= 0 && y <= ch;
+    const rightInside = x + width <= cw;
+    const bottomInside = y + height <= ch;
+    if (!(leftInside && topInside && rightInside && bottomInside)) {
+      return { valid: false, reason: "out_of_bounds" };
+    }
+  }
+
+  return { valid: true, area };
+}


### PR DESCRIPTION
Closes #56. Closes #191. Closes #192. Closes #193. Closes #194. Closes #195.

## Summary

Extends FR2 command control (Subissue 1.1 / #51) to cover **F2 — select specific sections to erase** (#40). The same pure-guard module now enforces an additional invariant for partial mode: **Start is rejected unless a valid section has been selected on the canvas.**

## Changes

- **`src/simulation/validateEraseArea.ts`** (new): pure `validateEraseArea(area, canvasBounds?)` returning a discriminated union with typed `EraseAreaInvalidReason` (`missing`, `non_positive_dimensions`, `non_finite_coordinates`, `out_of_bounds`).
- **`src/simulation/commandGuards.ts`**:
  - New optional `CommandContext` (`eraseMode`, `partialArea`, `canvasBounds`).
  - `canStart` / `evaluateCommand` consult the validator when `eraseMode === "partial"` (skipped when resuming from `paused`, so an in-flight partial erase can still resume without re-selecting).
  - Added `CommandRejectionCode` members `no_section_selected` and `invalid_section_bounds`.
  - F1 callers that omit the context stay backward-compatible.
- **`src/simulation/index.ts`**: re-export new types and the validator.
- **`src/hooks/useWhiteboardSimulation.ts`**: `startErase` passes `{ eraseMode, partialArea, canvasBounds }` into `canStart` and shows a section-specific `toast.info("Select an area to erase before starting")` for section rejections; all other rejections keep the existing copy.

## Sub-task decomposition (traceability)

- 2.1.1 (#191) Section-aware `canStart` signature
- 2.1.2 (#192) Typed rejection codes for section erase
- 2.1.3 (#193) Pure `validateEraseArea` helper
- 2.1.4 (#194) Wire partial-mode guards into `startErase`
- 2.1.5 (#195) Document section-aware FR2 command-control flow

## Verification

- `npx tsc --noEmit` clean.
- `npm run build` succeeds (no new warnings; only the pre-existing chunk-size notice).
- Manual flow:
  - Partial mode, no selection → Start rejected with `no_section_selected`; warning log + section-specific toast.
  - Partial mode, valid selection → Start proceeds through countdown → erase as before.
  - Full mode / resume from paused → unchanged behavior (backward compatible).
