### PR TITLE
Subissue 3.1 – FR2 Command Control for Scheduled Erase (#60)

### DIFF
--- a/src/simulation/commandGuards.ts
+++ b/src/simulation/commandGuards.ts
@@ -9,16 +9,21 @@ import {
   type CanvasBounds,
   type EraseAreaInvalidReason,
 } from "./validateEraseArea";
+import {
+  scheduleDueState,
+  type EraseSchedule,
+} from "./eraseSchedule";
 
 /**
  * FR2 command control — pure, side-effect free guards for start / pause / stop
- * commands covering both erase pipelines:
+ * commands covering every erase pipeline:
  *
  *   - F1 (#39) "automatic full erase at the press of a button"
  *   - F2 (#40) "select specific sections to erase"
+ *   - F3 (#41) "schedule erase after class"
  *
  * Used by the React bridge (`useWhiteboardSimulation`) and by any future
- * non-UI caller (teacher voice command, scheduled task, robot CLI).
+ * non-UI caller (teacher voice command, scheduled runner, robot CLI).
  *
  * Design:
  *   - Guards are pure functions; no React, no toasts, no timers.
@@ -27,6 +32,10 @@ import {
  *   - F2 callers pass an optional `CommandContext` describing the current
  *     erase mode and selected region. When `eraseMode === "partial"`, Start
  *     requires a valid `EraseArea` (non-null, positive dims, in-bounds).
+ *   - F3 callers use `canScheduledStart(schedule, now, status, context)`,
+ *     which composes schedule state (enabled, due, not expired) with the
+ *     existing `canStart` state/context invariants — partial-mode section
+ *     validation still applies to schedule-fired starts.
  *   - F1 callers may omit the context entirely; full-erase semantics apply.
  *
  * Rejection codes:
@@ -38,6 +47,10 @@ import {
  *                                selection.
  *   - `invalid_section_bounds` — F2: selected rectangle has non-positive
  *                                dimensions or lies outside the canvas.
+ *   - `schedule_disabled`      — F3: schedule exists but is toggled off.
+ *   - `schedule_not_due`       — F3: scheduled time has not yet arrived.
+ *   - `schedule_expired`       — F3: scheduled time is beyond the grace
+ *                                window; teacher must re-schedule.
  */
 
 export type CommandRejectionCode =
@@ -46,7 +59,10 @@ export type CommandRejectionCode =
   | "nothing_to_pause"
   | "nothing_to_stop"
   | "no_section_selected"
-  | "invalid_section_bounds";
+  | "invalid_section_bounds"
+  | "schedule_disabled"
+  | "schedule_not_due"
+  | "schedule_expired";
 
 export interface CommandRejection {
   code: CommandRejectionCode;
@@ -140,4 +156,50 @@ export function evaluateCommand(
     case "stop":
       return canStop(status);
   }
+}
+
+/**
+ * F3 Start guard. Composes schedule state with the FR2 state/context guard.
+ * Schedule-fired callers pass the `EraseSchedule` they intend to run plus
+ * `now` (injected for determinism). If the schedule is disabled, not yet
+ * due, or past its grace window, reject with the matching typed code.
+ * Otherwise delegate to `canStart` so partial-mode section validation and
+ * run-state rules still apply to scheduled starts.
+ */
+export function canScheduledStart(
+  schedule: EraseSchedule,
+  now: Date,
+  status: SystemStatus,
+  context: CommandContext = {},
+): CommandGuardResult {
+  if (!schedule.enabled) {
+    return deny(
+      "schedule_disabled",
+      status,
+      `Schedule '${schedule.label ?? schedule.id}' is disabled.`,
+    );
+  }
+
+  const due = scheduleDueState(schedule, now);
+  if (due === "pending") {
+    return deny(
+      "schedule_not_due",
+      status,
+      `Schedule '${schedule.label ?? schedule.id}' is not due yet.`,
+    );
+  }
+  if (due === "expired") {
+    return deny(
+      "schedule_expired",
+      status,
+      `Schedule '${schedule.label ?? schedule.id}' has expired — please re-schedule.`,
+    );
+  }
+
+  const scheduleContext: CommandContext = {
+    eraseMode: context.eraseMode ?? schedule.eraseMode,
+    partialArea: context.partialArea ?? schedule.partialArea ?? null,
+    canvasBounds: context.canvasBounds,
+  };
+  return canStart(status, scheduleContext);
 }

--- a/src/simulation/eraseSchedule.ts
+++ b/src/simulation/eraseSchedule.ts
@@ -1,0 +1,122 @@
+import type { EraseArea, EraseMode } from "@/types/whiteboard";
+
+/**
+ * F3 "schedule erase after class" — pure, side-effect free scheduling core.
+ *
+ * Intent: keep the policy questions ("is this schedule allowed to fire now?",
+ * "which scheduled erase should run next?") separate from the runner / UI.
+ * The FR2 command guard consumes these helpers to accept or reject
+ * schedule-driven Start commands with typed reasons.
+ *
+ * No timers, no DOM, no React. `now` is always injected so the caller
+ * controls clock sources and tests stay deterministic.
+ */
+
+export interface EraseSchedule {
+  id: string;
+  scheduledAt: Date;
+  eraseMode: EraseMode;
+  partialArea?: EraseArea | null;
+  enabled: boolean;
+  label?: string;
+}
+
+/**
+ * Window (ms) around `scheduledAt` during which the schedule is considered
+ * "due". Anything older than this is `expired`. Matches the FR2 audit
+ * expectation that a fire-attempt beyond the window is not silently
+ * retried — it's rejected so the teacher can re-schedule explicitly.
+ */
+export const SCHEDULE_DUE_WINDOW_MS = 60_000;
+
+export type ScheduleInvalidReason =
+  | "missing_id"
+  | "missing_time"
+  | "invalid_time"
+  | "past_time";
+
+export type ScheduleValidation =
+  | { valid: true; schedule: EraseSchedule }
+  | { valid: false; reason: ScheduleInvalidReason };
+
+export interface ScheduleInput {
+  id: string;
+  scheduledAt: Date | string | number;
+  eraseMode: EraseMode;
+  partialArea?: EraseArea | null;
+  enabled?: boolean;
+  label?: string;
+}
+
+const toDate = (value: Date | string | number): Date =>
+  value instanceof Date ? value : new Date(value);
+
+export function validateSchedule(
+  input: ScheduleInput,
+  now: Date = new Date(),
+): ScheduleValidation {
+  if (!input.id || typeof input.id !== "string") {
+    return { valid: false, reason: "missing_id" };
+  }
+  if (input.scheduledAt == null) {
+    return { valid: false, reason: "missing_time" };
+  }
+
+  const scheduledAt = toDate(input.scheduledAt);
+  if (!(scheduledAt instanceof Date) || Number.isNaN(scheduledAt.getTime())) {
+    return { valid: false, reason: "invalid_time" };
+  }
+
+  if (scheduledAt.getTime() + SCHEDULE_DUE_WINDOW_MS < now.getTime()) {
+    return { valid: false, reason: "past_time" };
+  }
+
+  return {
+    valid: true,
+    schedule: {
+      id: input.id,
+      scheduledAt,
+      eraseMode: input.eraseMode,
+      partialArea: input.partialArea ?? null,
+      enabled: input.enabled ?? true,
+      label: input.label,
+    },
+  };
+}
+
+export type ScheduleDueState = "pending" | "due" | "expired";
+
+export function scheduleDueState(
+  schedule: EraseSchedule,
+  now: Date = new Date(),
+): ScheduleDueState {
+  const delta = now.getTime() - schedule.scheduledAt.getTime();
+  if (delta < 0) return "pending";
+  if (delta <= SCHEDULE_DUE_WINDOW_MS) return "due";
+  return "expired";
+}
+
+export function isScheduleDue(
+  schedule: EraseSchedule,
+  now: Date = new Date(),
+): boolean {
+  return schedule.enabled && scheduleDueState(schedule, now) === "due";
+}
+
+/** Returns the nearest-in-time enabled, non-expired schedule, or null. */
+export function nextDueSchedule(
+  schedules: readonly EraseSchedule[],
+  now: Date = new Date(),
+): EraseSchedule | null {
+  let best: EraseSchedule | null = null;
+  for (const s of schedules) {
+    if (!s.enabled) continue;
+    if (scheduleDueState(s, now) === "expired") continue;
+    if (best == null) {
+      best = s;
+      continue;
+    }
+    if (s.scheduledAt.getTime() < best.scheduledAt.getTime()) best = s;
+  }
+  return best;
+}

--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -12,6 +12,7 @@ export { proximityWhenClear, proximityWhenObstacleDetected } from "./proximitySt
 export { createSnapshotNote, createSystemLog } from "./snapshotAndLog";
 export {
   canPause,
+  canScheduledStart,
   canStart,
   canStop,
   evaluateCommand,
@@ -28,3 +29,17 @@ export type {
   EraseAreaInvalidReason,
   EraseAreaValidation,
 } from "./validateEraseArea";
+export {
+  SCHEDULE_DUE_WINDOW_MS,
+  isScheduleDue,
+  nextDueSchedule,
+  scheduleDueState,
+  validateSchedule,
+} from "./eraseSchedule";
+export type {
+  EraseSchedule,
+  ScheduleDueState,
+  ScheduleInput,
+  ScheduleInvalidReason,
+  ScheduleValidation,
+} from "./eraseSchedule";


### PR DESCRIPTION
Closes #60. Closes #197. Closes #198. Closes #199. Closes #201. Closes #202.

## Summary

Extends FR2 command control to cover **F3 — schedule erase after class** (#41). The work is scoped to command-control primitives: a pure scheduling core plus a composed guard (`canScheduledStart`) that reuses the existing FR2/F1/F2 state and context invariants. The runner / teacher UI are deliberately left to sister subissues 3.2 and 3.3 so this PR stays tight and reviewable.

## Changes

- **`src/simulation/eraseSchedule.ts`** (new):
  - `EraseSchedule` (id, scheduledAt, eraseMode, partialArea, enabled, label).
  - `validateSchedule(input, now)` returning a discriminated union with typed `ScheduleInvalidReason` (`missing_id`, `missing_time`, `invalid_time`, `past_time`).
  - `scheduleDueState` (`pending | due | expired`), `isScheduleDue`, `nextDueSchedule`, and `SCHEDULE_DUE_WINDOW_MS` (1 minute grace).
  - All pure; `now` is always injected for deterministic tests.
- **`src/simulation/commandGuards.ts`**:
  - Added `CommandRejectionCode` members `schedule_disabled`, `schedule_not_due`, `schedule_expired`.
  - New `canScheduledStart(schedule, now, status, context)` — rejects disabled / pending / expired schedules with typed reasons, otherwise delegates to `canStart` so partial-mode section validation still applies to scheduled fires.
  - Schedule's own `eraseMode` / `partialArea` are used as defaults when the caller omits them in the `CommandContext`.
- **`src/simulation/index.ts`**: re-export schedule helpers, types, and the new guard.

## Sub-task decomposition (traceability)

- 3.1.1 (#197) `EraseSchedule` type + pure `validateSchedule`
- 3.1.2 (#198) Pure `isScheduleDue` / `nextDueSchedule` helpers
- 3.1.3 (#199) Typed rejection codes for scheduled erase
- 3.1.4 (#201) `canScheduledStart` guard composing FR2 + schedule
- 3.1.5 (#202) Document FR2 scheduled-erase command-control flow

## Verification

- `npx tsc --noEmit` clean.
- `npm run build` succeeds (no new warnings; only the pre-existing chunk-size notice).
- Fully backward compatible: no existing call site changes behavior. F1 and F2 paths continue through `canStart` / `canPause` / `canStop` exactly as today.
