### PR TITLE
Subissue 4.1 – FR2 Command Control for Touchscreen / Mobile (#61)

### DIFF
--- a/src/simulation/commandGuards.ts
+++ b/src/simulation/commandGuards.ts
@@ -13,6 +13,10 @@ import {
   scheduleDueState,
   type EraseSchedule,
 } from "./eraseSchedule";
+import {
+  checkTouchRateLimit,
+  DEFAULT_TOUCH_MIN_INTERVAL_MS,
+} from "./touchRateLimit";
 
 /**
  * FR2 command control — pure, side-effect free guards for start / pause / stop
@@ -36,6 +40,12 @@ import {
  *     which composes schedule state (enabled, due, not expired) with the
  *     existing `canStart` state/context invariants — partial-mode section
  *     validation still applies to schedule-fired starts.
+ *   - F4 callers annotate `context.source` (`touch` / `mouse` / `keyboard`
+ *     / `programmatic`) and optionally pass `lastCommandAt` +
+ *     `minTouchIntervalMs`. Touch-sourced commands fired within the
+ *     interval of a prior command are rejected with `rate_limited`, so
+ *     kiosk / mobile double-taps don't accidentally re-fire. Mouse and
+ *     keyboard sources remain un-rate-limited to preserve desktop UX.
  *   - F1 callers may omit the context entirely; full-erase semantics apply.
  *
  * Rejection codes:
@@ -51,6 +61,8 @@ import {
  *   - `schedule_not_due`       — F3: scheduled time has not yet arrived.
  *   - `schedule_expired`       — F3: scheduled time is beyond the grace
  *                                window; teacher must re-schedule.
+ *   - `rate_limited`           — F4: touch-sourced command fired within
+ *                                the minimum inter-command interval.
  */
 
 export type CommandRejectionCode =
@@ -62,7 +74,10 @@ export type CommandRejectionCode =
   | "invalid_section_bounds"
   | "schedule_disabled"
   | "schedule_not_due"
-  | "schedule_expired";
+  | "schedule_expired"
+  | "rate_limited";
+
+export type CommandSource = "touch" | "mouse" | "keyboard" | "programmatic";
 
 export interface CommandRejection {
   code: CommandRejectionCode;
@@ -78,7 +93,36 @@ export interface CommandContext {
   eraseMode?: EraseMode;
   partialArea?: EraseArea | null;
   canvasBounds?: CanvasBounds;
+  source?: CommandSource;
+  lastCommandAt?: Date | number | null;
+  now?: Date | number;
+  minTouchIntervalMs?: number;
 }
+
+/**
+ * F4: If the command arrived from a touchscreen / mobile tap, reject
+ * presses that land inside the minimum inter-command interval so the
+ * kiosk doesn't re-fire on finger bounce. Returns `null` when no
+ * rate-limit violation; a populated rejection otherwise.
+ */
+const touchRateRejection = (
+  context: CommandContext,
+  status: SystemStatus,
+): CommandGuardResult | null => {
+  if (context.source !== "touch") return null;
+  if (context.lastCommandAt == null) return null;
+
+  const interval = context.minTouchIntervalMs ?? DEFAULT_TOUCH_MIN_INTERVAL_MS;
+  const now = context.now ?? Date.now();
+  const check = checkTouchRateLimit(context.lastCommandAt, now, interval);
+  if (check.ok) return null;
+
+  return deny(
+    "rate_limited",
+    status,
+    `Touch command ignored — retry in ${Math.ceil(check.retryAfterMs)} ms.`,
+  );
+};
 
 const deny = (
   code: CommandRejectionCode,
@@ -108,6 +152,9 @@ export function canStart(
   status: SystemStatus,
   context: CommandContext = {},
 ): CommandGuardResult {
+  const rate = touchRateRejection(context, status);
+  if (rate) return rate;
+
   if (status === "erasing" || status === "countdown") {
     return deny("already_running", status, `Start ignored — erase is already ${status}.`);
   }
@@ -127,7 +174,13 @@ export function canStart(
   return { allowed: true };
 }
 
-export function canPause(status: SystemStatus): CommandGuardResult {
+export function canPause(
+  status: SystemStatus,
+  context: CommandContext = {},
+): CommandGuardResult {
+  const rate = touchRateRejection(context, status);
+  if (rate) return rate;
+
   if (status === "erasing") return { allowed: true };
   return deny(
     status === "idle" || status === "completed" ? "nothing_to_pause" : "invalid_state",
@@ -136,7 +189,13 @@ export function canPause(status: SystemStatus): CommandGuardResult {
   );
 }
 
-export function canStop(status: SystemStatus): CommandGuardResult {
+export function canStop(
+  status: SystemStatus,
+  context: CommandContext = {},
+): CommandGuardResult {
+  const rate = touchRateRejection(context, status);
+  if (rate) return rate;
+
   const stoppable: SystemStatus[] = ["erasing", "countdown", "paused", "obstacle-detected"];
   if (stoppable.includes(status)) return { allowed: true };
   return deny("nothing_to_stop", status, `Stop is unavailable while status is '${status}'.`);
@@ -152,9 +211,9 @@ export function evaluateCommand(
     case "start":
       return canStart(status, context);
     case "pause":
-      return canPause(status);
+      return canPause(status, context);
     case "stop":
-      return canStop(status);
+      return canStop(status, context);
   }
 }
 

--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -22,7 +22,13 @@ export type {
   CommandGuardResult,
   CommandRejection,
   CommandRejectionCode,
+  CommandSource,
 } from "./commandGuards";
+export {
+  DEFAULT_TOUCH_MIN_INTERVAL_MS,
+  checkTouchRateLimit,
+} from "./touchRateLimit";
+export type { TouchRateLimitResult } from "./touchRateLimit";
 export { validateEraseArea } from "./validateEraseArea";
 export type {
   CanvasBounds,

--- a/src/simulation/touchRateLimit.ts
+++ b/src/simulation/touchRateLimit.ts
@@ -1,0 +1,42 @@
+/**
+ * F4 "operate using a simple touchscreen or mobile interface" — pure
+ * rate-limit helper for FR2 command control.
+ *
+ * Touch UIs commonly deliver unintended double-taps (finger bounce, tremor,
+ * misalignment on the projected kiosk). FR2 must reject the second tap
+ * distinctly from `invalid_state` / `already_running` so the audit trail
+ * reflects *why* the command was dropped and the UI can surface a
+ * touch-specific message.
+ *
+ * This module is intentionally a single pure function: `checkTouchRateLimit`.
+ * No timers, no DOM, no React. `now` is injected for deterministic tests.
+ */
+
+/** Default minimum interval between two touch-sourced commands (ms). */
+export const DEFAULT_TOUCH_MIN_INTERVAL_MS = 350;
+
+export type TouchRateLimitResult =
+  | { ok: true }
+  | { ok: false; reason: "too_soon"; retryAfterMs: number };
+
+export function checkTouchRateLimit(
+  lastAt: Date | number | null | undefined,
+  now: Date | number,
+  minIntervalMs: number = DEFAULT_TOUCH_MIN_INTERVAL_MS,
+): TouchRateLimitResult {
+  if (lastAt == null) return { ok: true };
+  if (minIntervalMs <= 0) return { ok: true };
+
+  const lastMs = lastAt instanceof Date ? lastAt.getTime() : lastAt;
+  const nowMs = now instanceof Date ? now.getTime() : now;
+  if (!Number.isFinite(lastMs) || !Number.isFinite(nowMs)) return { ok: true };
+
+  const elapsed = nowMs - lastMs;
+  if (elapsed >= minIntervalMs) return { ok: true };
+
+  return {
+    ok: false,
+    reason: "too_soon",
+    retryAfterMs: Math.max(0, minIntervalMs - elapsed),
+  };
+}


### PR DESCRIPTION
Closes #61. Closes #204. Closes #205. Closes #206. Closes #207. Closes #208.

## Summary

Extends FR2 command control to cover **F4 — operate using a simple touchscreen or mobile interface** (#42). Annotates every command with its input source and rejects touch-sourced double-taps inside a minimum inter-command interval. Mouse and keyboard paths are unchanged, so desktop UX is preserved.

## Changes

- **`src/simulation/touchRateLimit.ts`** (new):
  - `checkTouchRateLimit(lastAt, now, minIntervalMs)` returning a discriminated union (`{ ok: true } | { ok: false, reason: "too_soon", retryAfterMs }`).
  - `DEFAULT_TOUCH_MIN_INTERVAL_MS = 350` (kiosk / mobile sweet spot).
  - Pure; `now` is injected for deterministic tests.
- **`src/simulation/commandGuards.ts`**:
  - New `CommandSource` union (`touch | mouse | keyboard | programmatic`).
  - `CommandContext` extended with `source`, `lastCommandAt`, `now`, `minTouchIntervalMs`.
  - New `rate_limited` rejection code.
  - Shared `touchRateRejection` pre-check applied to `canStart`, `canPause`, `canStop`. Only triggers when `source === "touch"` and `lastCommandAt` is provided — otherwise every existing call site keeps its exact behavior.
  - `evaluateCommand` threads the context through all three actions.
- **`src/simulation/index.ts`**: re-export `CommandSource`, `checkTouchRateLimit`, `DEFAULT_TOUCH_MIN_INTERVAL_MS`, `TouchRateLimitResult`.

## Sub-task decomposition (traceability)

- 4.1.1 (#204) `CommandSource` type in `CommandContext`
- 4.1.2 (#205) Pure `checkTouchRateLimit` helper
- 4.1.3 (#206) `rate_limited` rejection code
- 4.1.4 (#207) Apply touch rate-limit in start / pause / stop guards
- 4.1.5 (#208) Document FR2 touchscreen / mobile command-control flow

## Verification

- `npx tsc --noEmit` clean.
- `npm run build` succeeds (only the pre-existing chunk-size notice).
- Fully backward compatible: existing call sites omit `source`, so the touch check short-circuits immediately and F1 / F2 / F3 behavior is identical to before.
