### PR TITLE
Subissue 5.1 – FR4 Safety and Proximity Pipeline for F5 (#65)

### DIFF
--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -9,6 +9,35 @@ export { applyEraseToCanvas } from "./eraseCanvas";
 export { computeEraseProgressTick } from "./eraseProgress";
 export type { EraseProgressTick } from "./eraseProgress";
 export { proximityWhenClear, proximityWhenObstacleDetected } from "./proximityState";
+export {
+  DEFAULT_PROXIMITY_THRESHOLDS,
+  classifyProximityZone,
+} from "./proximityClassifier";
+export type {
+  ProximityZone,
+  ProximityZoneThresholds,
+} from "./proximityClassifier";
+export {
+  DEFAULT_HYSTERESIS,
+  initialHysteresisState,
+  reduceProximityHysteresis,
+} from "./proximityHysteresis";
+export type {
+  HysteresisConfig,
+  ProximityHysteresisState,
+} from "./proximityHysteresis";
+export { evaluateSafetyAction } from "./safetyPolicy";
+export type {
+  SafetyAction,
+  SafetyDecision,
+  SafetyReason,
+} from "./safetyPolicy";
+export { createSafetyEvent } from "./safetyEvents";
+export type {
+  SafetyEvent,
+  SafetyEventInput,
+  SafetyEventKind,
+} from "./safetyEvents";
 export { createSnapshotNote, createSystemLog } from "./snapshotAndLog";
 export {
   canPause,

--- a/src/simulation/proximityClassifier.ts
+++ b/src/simulation/proximityClassifier.ts
@@ -1,0 +1,41 @@
+/**
+ * F5 "operate safely near students" — pure proximity zone classifier.
+ *
+ * The existing `ProximitySensor` gives us a raw distance (meters) and a
+ * single obstacle threshold. FR4 for F5 needs a richer safety model that
+ * distinguishes an early-warning band from a hard-stop band so the robot
+ * can slow / pause before a student reaches true danger distance.
+ *
+ * Zones (inclusive of the upper bound):
+ *   - `danger`  : distance <= `dangerMaxM`      (immediate pause)
+ *   - `warning` : dangerMaxM < distance <= warnMaxM (visual / audible cue)
+ *   - `clear`   : distance  > warnMaxM          (normal operation)
+ *
+ * Pure — no React, no DOM, no timers. Used by the hysteresis reducer and
+ * safety policy engine.
+ */
+
+export type ProximityZone = "clear" | "warning" | "danger";
+
+export interface ProximityZoneThresholds {
+  /** Distance (m) at or below which the robot must stop immediately. */
+  dangerMaxM: number;
+  /** Distance (m) at or below which the robot should warn / slow. */
+  warnMaxM: number;
+}
+
+/** Defaults derived from FR4 (0.5 m obstacle threshold) with a 0.5 m warning band. */
+export const DEFAULT_PROXIMITY_THRESHOLDS: ProximityZoneThresholds = {
+  dangerMaxM: 0.5,
+  warnMaxM: 1.0,
+};
+
+export function classifyProximityZone(
+  distanceMeters: number,
+  thresholds: ProximityZoneThresholds = DEFAULT_PROXIMITY_THRESHOLDS,
+): ProximityZone {
+  if (!Number.isFinite(distanceMeters)) return "danger";
+  if (distanceMeters <= thresholds.dangerMaxM) return "danger";
+  if (distanceMeters <= thresholds.warnMaxM) return "warning";
+  return "clear";
+}

--- a/src/simulation/proximityHysteresis.ts
+++ b/src/simulation/proximityHysteresis.ts
@@ -1,0 +1,91 @@
+import type { ProximityZone } from "./proximityClassifier";
+
+/**
+ * F5 / FR4 — hysteresis for proximity transitions.
+ *
+ * Raw sensor streams flap: one noisy reading can cross a threshold and
+ * trip a pause, the next reading clears it, and the erase state
+ * oscillates. This reducer requires N consecutive samples of the same
+ * candidate zone before the committed zone changes.
+ *
+ * Direction-aware:
+ *   - Into a more-dangerous zone (clear→warning, warning→danger,
+ *     clear→danger) commits after `escalateSamples`.
+ *   - Into a less-dangerous zone (danger→warning, warning→clear,
+ *     danger→clear) commits after `deescalateSamples` — usually larger,
+ *     so we're conservative about resuming.
+ *
+ * Pure reducer: `reduceProximityHysteresis(state, sample, config) =>
+ * nextState`. No timers, no DOM. The caller (React hook, robot runner)
+ * owns the clock and the sample cadence.
+ */
+
+export interface HysteresisConfig {
+  escalateSamples: number;
+  deescalateSamples: number;
+}
+
+export const DEFAULT_HYSTERESIS: HysteresisConfig = {
+  escalateSamples: 1,
+  deescalateSamples: 3,
+};
+
+export interface ProximityHysteresisState {
+  committedZone: ProximityZone;
+  candidateZone: ProximityZone;
+  candidateRunLength: number;
+}
+
+export function initialHysteresisState(
+  zone: ProximityZone = "clear",
+): ProximityHysteresisState {
+  return {
+    committedZone: zone,
+    candidateZone: zone,
+    candidateRunLength: 0,
+  };
+}
+
+const severity: Record<ProximityZone, number> = {
+  clear: 0,
+  warning: 1,
+  danger: 2,
+};
+
+const isEscalation = (from: ProximityZone, to: ProximityZone): boolean =>
+  severity[to] > severity[from];
+
+export function reduceProximityHysteresis(
+  state: ProximityHysteresisState,
+  sampleZone: ProximityZone,
+  config: HysteresisConfig = DEFAULT_HYSTERESIS,
+): ProximityHysteresisState {
+  if (sampleZone === state.committedZone) {
+    return {
+      committedZone: state.committedZone,
+      candidateZone: state.committedZone,
+      candidateRunLength: 0,
+    };
+  }
+
+  const nextRun =
+    state.candidateZone === sampleZone ? state.candidateRunLength + 1 : 1;
+
+  const required = isEscalation(state.committedZone, sampleZone)
+    ? Math.max(1, config.escalateSamples)
+    : Math.max(1, config.deescalateSamples);
+
+  if (nextRun >= required) {
+    return {
+      committedZone: sampleZone,
+      candidateZone: sampleZone,
+      candidateRunLength: 0,
+    };
+  }
+
+  return {
+    committedZone: state.committedZone,
+    candidateZone: sampleZone,
+    candidateRunLength: nextRun,
+  };
+}

--- a/src/simulation/safetyEvents.ts
+++ b/src/simulation/safetyEvents.ts
@@ -1,0 +1,72 @@
+import type { ProximityZone } from "./proximityClassifier";
+
+/**
+ * F5 / FR4 safety audit events.
+ *
+ * Typed factories that record *why* the robot paused / resumed /
+ * refused to start, so the audit log and future reports can cite
+ * proximity causes without string matching. Pure — no React, no DOM,
+ * no timers. Timestamps are injected for determinism.
+ */
+
+export type SafetyEventKind =
+  | "entered_warning"
+  | "entered_danger"
+  | "cleared"
+  | "committed_pause"
+  | "committed_resume"
+  | "refused_start";
+
+export interface SafetyEvent {
+  id: string;
+  kind: SafetyEventKind;
+  zone: ProximityZone;
+  distanceMeters: number | null;
+  at: Date;
+  message: string;
+}
+
+let counter = 0;
+const nextId = (prefix: string, at: Date): string => {
+  counter = (counter + 1) % 1_000_000;
+  return `${prefix}-${at.getTime()}-${counter.toString(36)}`;
+};
+
+export interface SafetyEventInput {
+  zone: ProximityZone;
+  distanceMeters?: number | null;
+  at?: Date;
+  message?: string;
+}
+
+const baseMessage = (kind: SafetyEventKind, zone: ProximityZone): string => {
+  switch (kind) {
+    case "entered_warning":
+      return `FR4: student entered warning zone (${zone}).`;
+    case "entered_danger":
+      return `FR4: student entered danger zone — erase paused for safety.`;
+    case "cleared":
+      return `FR4: area cleared — safe to resume.`;
+    case "committed_pause":
+      return `FR4: pause committed due to proximity.`;
+    case "committed_resume":
+      return `FR4: resume committed after area cleared.`;
+    case "refused_start":
+      return `FR4: start refused — student still in danger zone.`;
+  }
+};
+
+export function createSafetyEvent(
+  kind: SafetyEventKind,
+  input: SafetyEventInput,
+): SafetyEvent {
+  const at = input.at ?? new Date();
+  return {
+    id: nextId("safety", at),
+    kind,
+    zone: input.zone,
+    distanceMeters: input.distanceMeters ?? null,
+    at,
+    message: input.message ?? baseMessage(kind, input.zone),
+  };
+}

--- a/src/simulation/safetyPolicy.ts
+++ b/src/simulation/safetyPolicy.ts
@@ -1,0 +1,74 @@
+import type { SystemStatus } from "@/types/whiteboard";
+import type { ProximityZone } from "./proximityClassifier";
+
+/**
+ * F5 / FR4 safety policy engine.
+ *
+ * Pure mapping from `(SystemStatus, currentZone, previousZone)` to a
+ * required `SafetyAction`. Used by the React bridge and by any
+ * non-UI runner (robot CLI) so "when a student steps into the danger
+ * band, the erase pauses" is described once and tested once.
+ *
+ * Actions:
+ *   - `continue` — keep running, no change.
+ *   - `pause`    — pause an active erase because zone escalated to
+ *                  danger; caller transitions status → `obstacle-detected`.
+ *   - `halt`     — refuse to start (or cancel a countdown) because the
+ *                  student is already in the danger zone.
+ *   - `resume`   — the previously-tripped condition has cleared and the
+ *                  erase should continue; caller transitions status
+ *                  back to `erasing`.
+ *   - `no_op`    — nothing to do in the current combination.
+ */
+
+export type SafetyAction = "continue" | "pause" | "halt" | "resume" | "no_op";
+
+export type SafetyReason =
+  | "student_in_danger_zone"
+  | "student_in_warning_zone"
+  | "area_cleared"
+  | "idle_unchanged";
+
+export interface SafetyDecision {
+  action: SafetyAction;
+  reason: SafetyReason;
+  zone: ProximityZone;
+}
+
+const decide = (
+  action: SafetyAction,
+  reason: SafetyReason,
+  zone: ProximityZone,
+): SafetyDecision => ({ action, reason, zone });
+
+export function evaluateSafetyAction(
+  status: SystemStatus,
+  currentZone: ProximityZone,
+  previousZone: ProximityZone = currentZone,
+): SafetyDecision {
+  if (currentZone === "danger") {
+    if (status === "erasing" || status === "countdown") {
+      return decide("pause", "student_in_danger_zone", currentZone);
+    }
+    if (status === "idle" || status === "completed" || status === "paused") {
+      return decide("halt", "student_in_danger_zone", currentZone);
+    }
+    return decide("no_op", "student_in_danger_zone", currentZone);
+  }
+
+  if (currentZone === "warning") {
+    return decide(
+      status === "erasing" || status === "countdown" ? "continue" : "no_op",
+      "student_in_warning_zone",
+      currentZone,
+    );
+  }
+
+  if (status === "obstacle-detected" && previousZone !== "clear") {
+    return decide("resume", "area_cleared", currentZone);
+  }
+  if (status === "erasing" || status === "countdown") {
+    return decide("continue", "area_cleared", currentZone);
+  }
+  return decide("no_op", "idle_unchanged", currentZone);
+}


### PR DESCRIPTION
Closes #65. Closes #210. Closes #211. Closes #212. Closes #213. Closes #214.

## Summary

Extends FR4 safety and proximity detection to cover **F5 — operate safely near students** (#43). Today's proximity state is binary (`obstacle` / `clear`); this PR introduces a richer, purely functional safety pipeline so a single decision surface governs pause / halt / resume across the React bridge and any non-UI runner (robot CLI).

## Pipeline

```
raw sensor distance (m)
  → classifyProximityZone        (clear | warning | danger)
  → reduceProximityHysteresis    (debounce flapping samples)
  → evaluateSafetyAction         ((status, zone, prevZone) → action)
  → createSafetyEvent            (typed audit record)
```

## Changes

- **`src/simulation/proximityClassifier.ts`** (new): `classifyProximityZone(distanceMeters, thresholds?)` returning `ProximityZone = clear | warning | danger`. Defaults: `dangerMaxM = 0.5 m` (FR4 hard stop), `warnMaxM = 1.0 m` (early warn band).
- **`src/simulation/proximityHysteresis.ts`** (new): `reduceProximityHysteresis(state, sample, config?)` — direction-aware: escalate after 1 sample, de-escalate after 3 (conservative about resuming near a student).
- **`src/simulation/safetyPolicy.ts`** (new): `evaluateSafetyAction(status, zone, prevZone?)` → `SafetyDecision { action, reason, zone }` where action ∈ `continue | pause | halt | resume | no_op`. Refuses Start while the student is still in the danger zone; commits Resume only on an actual clear transition.
- **`src/simulation/safetyEvents.ts`** (new): `createSafetyEvent` factory with typed `SafetyEventKind = entered_warning | entered_danger | cleared | committed_pause | committed_resume | refused_start`. Timestamps injectable for determinism.
- **`src/simulation/index.ts`**: re-export every new symbol and type.

All modules are pure — no React, no DOM, no timers — so they're trivially unit-testable and re-usable from the robot-side Python bridge later.

## Sub-task decomposition (traceability)

- 5.1.1 (#210) Pure `classifyProximityZone`
- 5.1.2 (#211) Hysteresis reducer for proximity transitions
- 5.1.3 (#212) Safety policy engine `evaluateSafetyAction`
- 5.1.4 (#213) Typed `SafetyEvent` audit factories
- 5.1.5 (#214) Document FR4 proximity / safety pipeline

## Verification

- `npx tsc --noEmit` clean.
- `npm run build` succeeds (only the pre-existing chunk-size notice).
- Fully backward compatible: existing `proximityWhenClear` / `proximityWhenObstacleDetected` helpers and the hook's obstacle toggle are unchanged. Hook wiring and UI surfacing are deferred to sister subissues 5.2 / 5.3.
