### PR TITLE
Subissue 6.1 – FR2 Pre-Erase Notification for F6 (#67)

### DIFF
--- a/src/simulation/commandGuards.ts
+++ b/src/simulation/commandGuards.ts
@@ -46,6 +46,11 @@ import {
  *     interval of a prior command are rejected with `rate_limited`, so
  *     kiosk / mobile double-taps don't accidentally re-fire. Mouse and
  *     keyboard sources remain un-rate-limited to preserve desktop UX.
+ *   - F6 callers set `context.requireAcknowledgment = true` and supply
+ *     `acknowledgedAt` once the teacher dismisses the pre-erase warning.
+ *     Start is rejected with `notification_not_acknowledged` until the
+ *     warning is acknowledged, so accidental taps during the grace
+ *     window can't bypass the "notify me before erase" policy.
  *   - F1 callers may omit the context entirely; full-erase semantics apply.
  *
  * Rejection codes:
@@ -63,6 +68,9 @@ import {
  *                                window; teacher must re-schedule.
  *   - `rate_limited`           — F4: touch-sourced command fired within
  *                                the minimum inter-command interval.
+ *   - `notification_not_acknowledged`
+ *                              — F6: Start pressed while a pre-erase
+ *                                warning is still pending acknowledgment.
  */
 
 export type CommandRejectionCode =
@@ -75,7 +83,8 @@ export type CommandRejectionCode =
   | "schedule_disabled"
   | "schedule_not_due"
   | "schedule_expired"
-  | "rate_limited";
+  | "rate_limited"
+  | "notification_not_acknowledged";
 
 export type CommandSource = "touch" | "mouse" | "keyboard" | "programmatic";
 
@@ -97,6 +106,8 @@ export interface CommandContext {
   lastCommandAt?: Date | number | null;
   now?: Date | number;
   minTouchIntervalMs?: number;
+  requireAcknowledgment?: boolean;
+  acknowledgedAt?: Date | number | null;
 }
 
 /**
@@ -169,6 +180,14 @@ export function canStart(
   if (context.eraseMode === "partial" && status !== "paused") {
     const check = validateEraseArea(context.partialArea, context.canvasBounds);
     if (!check.valid) return sectionRejection(status, check.reason);
+  }
+
+  if (context.requireAcknowledgment && context.acknowledgedAt == null) {
+    return deny(
+      "notification_not_acknowledged",
+      status,
+      "Start ignored — acknowledge the pre-erase warning before starting.",
+    );
   }
 
   return { allowed: true };

--- a/src/simulation/eraseNotification.ts
+++ b/src/simulation/eraseNotification.ts
@@ -1,0 +1,85 @@
+/**
+ * F6 "notify me before the whiteboard is erased" — pure pre-erase
+ * notification pipeline.
+ *
+ * Maps a planned erase start into three lifecycle moments:
+ *   - warnAt       : first user-visible notification (e.g. banner / toast)
+ *   - finalWarnAt  : last-chance heads-up (e.g. full-screen countdown)
+ *   - eraseAt      : the actual trajectory fire
+ *
+ * and derives the current phase from `now`. Pure — no timers, no DOM,
+ * no React. Consumed by the React bridge and the FR2 command guard.
+ */
+
+export type CountdownPhase =
+  | "idle"
+  | "pre_warn"
+  | "countdown"
+  | "final"
+  | "expired";
+
+/** Defaults match the existing 10 s COUNTDOWN_SECONDS with a 30 s lead-in. */
+export const DEFAULT_PRE_WARN_MS = 30_000;
+export const DEFAULT_COUNTDOWN_MS = 10_000;
+export const DEFAULT_FINAL_MS = 3_000;
+
+export interface EraseNotificationConfig {
+  preWarnMs?: number;
+  countdownMs?: number;
+  finalMs?: number;
+}
+
+export interface EraseNotificationPlan {
+  warnAt: Date;
+  countdownAt: Date;
+  finalWarnAt: Date;
+  eraseAt: Date;
+  preWarnMs: number;
+  countdownMs: number;
+  finalMs: number;
+}
+
+const toDate = (value: Date | string | number): Date =>
+  value instanceof Date ? value : new Date(value);
+
+export function buildEraseNotificationPlan(
+  eraseAt: Date | string | number,
+  config: EraseNotificationConfig = {},
+): EraseNotificationPlan {
+  const erase = toDate(eraseAt);
+  const preWarnMs = Math.max(0, config.preWarnMs ?? DEFAULT_PRE_WARN_MS);
+  const countdownMs = Math.max(0, config.countdownMs ?? DEFAULT_COUNTDOWN_MS);
+  const finalMs = Math.max(0, config.finalMs ?? DEFAULT_FINAL_MS);
+  const eraseMs = erase.getTime();
+
+  return {
+    warnAt: new Date(eraseMs - preWarnMs - countdownMs),
+    countdownAt: new Date(eraseMs - countdownMs),
+    finalWarnAt: new Date(eraseMs - finalMs),
+    eraseAt: erase,
+    preWarnMs,
+    countdownMs,
+    finalMs,
+  };
+}
+
+export interface CountdownTick {
+  phase: CountdownPhase;
+  remainingMs: number;
+}
+
+export function getCountdownPhase(
+  now: Date | number,
+  plan: EraseNotificationPlan,
+): CountdownTick {
+  const nowMs = now instanceof Date ? now.getTime() : now;
+  const remainingMs = Math.max(0, plan.eraseAt.getTime() - nowMs);
+
+  if (nowMs < plan.warnAt.getTime()) return { phase: "idle", remainingMs };
+  if (nowMs < plan.countdownAt.getTime())
+    return { phase: "pre_warn", remainingMs };
+  if (nowMs < plan.finalWarnAt.getTime())
+    return { phase: "countdown", remainingMs };
+  if (nowMs < plan.eraseAt.getTime()) return { phase: "final", remainingMs };
+  return { phase: "expired", remainingMs: 0 };
+}

--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -58,6 +58,25 @@ export {
   checkTouchRateLimit,
 } from "./touchRateLimit";
 export type { TouchRateLimitResult } from "./touchRateLimit";
+export {
+  DEFAULT_PRE_WARN_MS,
+  DEFAULT_COUNTDOWN_MS,
+  DEFAULT_FINAL_MS,
+  buildEraseNotificationPlan,
+  getCountdownPhase,
+} from "./eraseNotification";
+export type {
+  CountdownPhase,
+  CountdownTick,
+  EraseNotificationConfig,
+  EraseNotificationPlan,
+} from "./eraseNotification";
+export { createNotificationEvent } from "./notificationEvents";
+export type {
+  NotificationEvent,
+  NotificationEventInput,
+  NotificationEventKind,
+} from "./notificationEvents";
 export { validateEraseArea } from "./validateEraseArea";
 export type {
   CanvasBounds,

--- a/src/simulation/notificationEvents.ts
+++ b/src/simulation/notificationEvents.ts
@@ -1,0 +1,64 @@
+import type { CountdownPhase } from "./eraseNotification";
+
+/**
+ * F6 notification audit events. Typed factories mirroring the FR4
+ * `SafetyEvent` pattern so the audit trail records *why* a pre-erase
+ * warning was raised, acknowledged, or canceled. Pure — timestamps are
+ * injectable.
+ */
+
+export type NotificationEventKind =
+  | "warning_shown"
+  | "acknowledged"
+  | "canceled_during_grace"
+  | "auto_started";
+
+export interface NotificationEvent {
+  id: string;
+  kind: NotificationEventKind;
+  phase: CountdownPhase;
+  at: Date;
+  message: string;
+}
+
+let counter = 0;
+const nextId = (at: Date): string => {
+  counter = (counter + 1) % 1_000_000;
+  return `notify-${at.getTime()}-${counter.toString(36)}`;
+};
+
+const baseMessage = (
+  kind: NotificationEventKind,
+  phase: CountdownPhase,
+): string => {
+  switch (kind) {
+    case "warning_shown":
+      return `FR2/F6: pre-erase warning shown (phase=${phase}).`;
+    case "acknowledged":
+      return `FR2/F6: user acknowledged pre-erase warning.`;
+    case "canceled_during_grace":
+      return `FR2/F6: user canceled erase during ${phase} phase.`;
+    case "auto_started":
+      return `FR2/F6: grace window elapsed — erase auto-started.`;
+  }
+};
+
+export interface NotificationEventInput {
+  phase: CountdownPhase;
+  at?: Date;
+  message?: string;
+}
+
+export function createNotificationEvent(
+  kind: NotificationEventKind,
+  input: NotificationEventInput,
+): NotificationEvent {
+  const at = input.at ?? new Date();
+  return {
+    id: nextId(at),
+    kind,
+    phase: input.phase,
+    at,
+    message: input.message ?? baseMessage(kind, input.phase),
+  };
+}


### PR DESCRIPTION
Closes #67. Closes #216. Closes #217. Closes #218. Closes #219. Closes #220.

## Summary

Extends FR2 command control to cover **F6 — notify me before the whiteboard is erased** (#44). Introduces a pure pre-erase notification pipeline so the teacher always sees a warning before the robot fires, and accidental taps inside the grace window can't bypass the policy.

## Pipeline

```
eraseAt → buildEraseNotificationPlan → getCountdownPhase(now)
       → canStart({ requireAcknowledgment, acknowledgedAt })
       → createNotificationEvent(kind, …)
```

## Changes

- **`src/simulation/eraseNotification.ts`** (new):
  - `EraseNotificationPlan` with `warnAt`, `countdownAt`, `finalWarnAt`, `eraseAt`.
  - `buildEraseNotificationPlan(eraseAt, config)` with defaults `DEFAULT_PRE_WARN_MS = 30s`, `DEFAULT_COUNTDOWN_MS = 10s`, `DEFAULT_FINAL_MS = 3s`.
  - `getCountdownPhase(now, plan)` → `{ phase: idle | pre_warn | countdown | final | expired, remainingMs }`.
- **`src/simulation/notificationEvents.ts`** (new): typed `NotificationEventKind` factories (`warning_shown`, `acknowledged`, `canceled_during_grace`, `auto_started`) with injectable timestamps (mirrors `SafetyEvent`).
- **`src/simulation/commandGuards.ts`**:
  - `CommandContext` extended with `requireAcknowledgment` + `acknowledgedAt`.
  - New rejection code `notification_not_acknowledged`.
  - `canStart` rejects un-acknowledged starts when the flag is set; all other paths unchanged.
- **`src/simulation/index.ts`**: re-export every new symbol and type.

All modules are pure (no React, no DOM, no timers) — consistent with the rest of `@/simulation`.

## Sub-task decomposition (traceability)

- 6.1.1 (#216) `EraseNotificationPlan` + `buildEraseNotificationPlan`
- 6.1.2 (#217) Pure `getCountdownPhase` helper
- 6.1.3 (#218) `requireAcknowledgment` in `canStart`
- 6.1.4 (#219) Typed `NotificationEvent` audit factories
- 6.1.5 (#220) Document FR2 pre-erase notification flow

## Verification

- `npx tsc --noEmit` clean.
- `npm run build` succeeds (only the pre-existing chunk-size notice).
- Fully backward compatible: existing `COUNTDOWN_SECONDS` constant and countdown UI continue to work untouched; the new guard branch fires only when `requireAcknowledgment === true`.
