### PR TITLE
Subissue 8.1 – FR2 Voice Commands for F8 (#71)

### DIFF
--- a/src/simulation/commandGuards.ts
+++ b/src/simulation/commandGuards.ts
@@ -17,6 +17,10 @@ import {
   checkTouchRateLimit,
   DEFAULT_TOUCH_MIN_INTERVAL_MS,
 } from "./touchRateLimit";
+import {
+  DEFAULT_VOICE_CONFIDENCE_MIN,
+  type VoiceIntent,
+} from "./voiceIntent";
 
 /**
  * FR2 command control — pure, side-effect free guards for start / pause / stop
@@ -51,6 +55,11 @@ import {
  *     Start is rejected with `notification_not_acknowledged` until the
  *     warning is acknowledged, so accidental taps during the grace
  *     window can't bypass the "notify me before erase" policy.
+ *   - F8 callers set `context.source = "voice"` and pass a `voiceIntent`
+ *     (see `parseVoiceIntent`). The guard rejects when the intent's
+ *     action mismatches the attempted action or the confidence is below
+ *     `voiceConfidenceMin` (default `DEFAULT_VOICE_CONFIDENCE_MIN`).
+ *     Non-voice sources are unaffected.
  *   - F1 callers may omit the context entirely; full-erase semantics apply.
  *
  * Rejection codes:
@@ -71,6 +80,12 @@ import {
  *   - `notification_not_acknowledged`
  *                              — F6: Start pressed while a pre-erase
  *                                warning is still pending acknowledgment.
+ *   - `low_confidence`         — F8: voice intent confidence below
+ *                                threshold.
+ *   - `unrecognized_voice_command`
+ *                              — F8: transcript parsed but no known
+ *                                action, or intent action mismatches
+ *                                the attempted command.
  */
 
 export type CommandRejectionCode =
@@ -84,9 +99,16 @@ export type CommandRejectionCode =
   | "schedule_not_due"
   | "schedule_expired"
   | "rate_limited"
-  | "notification_not_acknowledged";
+  | "notification_not_acknowledged"
+  | "low_confidence"
+  | "unrecognized_voice_command";
 
-export type CommandSource = "touch" | "mouse" | "keyboard" | "programmatic";
+export type CommandSource =
+  | "touch"
+  | "mouse"
+  | "keyboard"
+  | "programmatic"
+  | "voice";
 
 export interface CommandRejection {
   code: CommandRejectionCode;
@@ -108,7 +130,53 @@ export interface CommandContext {
   minTouchIntervalMs?: number;
   requireAcknowledgment?: boolean;
   acknowledgedAt?: Date | number | null;
+  voiceIntent?: VoiceIntent | null;
+  voiceConfidenceMin?: number;
 }
+
+/**
+ * F8: validate a voice-sourced command against its parsed intent. Runs
+ * only when `source === "voice"`. Returns a populated rejection when
+ * the intent mismatches / is below threshold, otherwise null.
+ */
+const voiceRejection = (
+  action: CommandAction,
+  context: CommandContext,
+  status: SystemStatus,
+): CommandGuardResult | null => {
+  if (context.source !== "voice") return null;
+  const intent = context.voiceIntent;
+  if (intent == null) {
+    return deny(
+      "unrecognized_voice_command",
+      status,
+      "Voice command ignored — no intent parsed from transcript.",
+    );
+  }
+  if (intent.action == null) {
+    return deny(
+      "unrecognized_voice_command",
+      status,
+      `Voice command ignored — transcript '${intent.normalized}' did not match a known action.`,
+    );
+  }
+  if (intent.action !== action) {
+    return deny(
+      "unrecognized_voice_command",
+      status,
+      `Voice command mismatch — heard '${intent.action}', expected '${action}'.`,
+    );
+  }
+  const min = context.voiceConfidenceMin ?? DEFAULT_VOICE_CONFIDENCE_MIN;
+  if (intent.confidence < min) {
+    return deny(
+      "low_confidence",
+      status,
+      `Voice command ignored — confidence ${intent.confidence.toFixed(2)} below ${min.toFixed(2)}.`,
+    );
+  }
+  return null;
+};
 
 /**
  * F4: If the command arrived from a touchscreen / mobile tap, reject
@@ -165,6 +233,8 @@ export function canStart(
 ): CommandGuardResult {
   const rate = touchRateRejection(context, status);
   if (rate) return rate;
+  const voice = voiceRejection("start", context, status);
+  if (voice) return voice;
 
   if (status === "erasing" || status === "countdown") {
     return deny("already_running", status, `Start ignored — erase is already ${status}.`);
@@ -199,6 +269,8 @@ export function canPause(
 ): CommandGuardResult {
   const rate = touchRateRejection(context, status);
   if (rate) return rate;
+  const voice = voiceRejection("pause", context, status);
+  if (voice) return voice;
 
   if (status === "erasing") return { allowed: true };
   return deny(
@@ -214,6 +286,8 @@ export function canStop(
 ): CommandGuardResult {
   const rate = touchRateRejection(context, status);
   if (rate) return rate;
+  const voice = voiceRejection("stop", context, status);
+  if (voice) return voice;
 
   const stoppable: SystemStatus[] = ["erasing", "countdown", "paused", "obstacle-detected"];
   if (stoppable.includes(status)) return { allowed: true };

--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -77,6 +77,21 @@ export type {
   NotificationEventInput,
   NotificationEventKind,
 } from "./notificationEvents";
+export {
+  DEFAULT_VOICE_CONFIDENCE_MIN,
+  DEFAULT_WAKE_WORDS,
+  parseVoiceIntent,
+} from "./voiceIntent";
+export type {
+  ParseVoiceIntentOptions,
+  VoiceIntent,
+} from "./voiceIntent";
+export { createVoiceEvent } from "./voiceEvents";
+export type {
+  VoiceEvent,
+  VoiceEventInput,
+  VoiceEventKind,
+} from "./voiceEvents";
 export { validateEraseArea } from "./validateEraseArea";
 export type {
   CanvasBounds,

--- a/src/simulation/voiceEvents.ts
+++ b/src/simulation/voiceEvents.ts
@@ -1,0 +1,72 @@
+import type { CommandAction } from "@/types/whiteboard";
+
+/**
+ * F8 voice audit events. Typed factories mirroring `SafetyEvent` /
+ * `NotificationEvent` so the audit log records *why* a voice command
+ * was honored or dropped. Pure; timestamps are injectable.
+ */
+
+export type VoiceEventKind =
+  | "utterance_heard"
+  | "intent_parsed"
+  | "intent_rejected"
+  | "wake_word_missed";
+
+export interface VoiceEvent {
+  id: string;
+  kind: VoiceEventKind;
+  action: CommandAction | null;
+  confidence: number | null;
+  transcript: string;
+  at: Date;
+  message: string;
+}
+
+let counter = 0;
+const nextId = (at: Date): string => {
+  counter = (counter + 1) % 1_000_000;
+  return `voice-${at.getTime()}-${counter.toString(36)}`;
+};
+
+const baseMessage = (
+  kind: VoiceEventKind,
+  action: CommandAction | null,
+  confidence: number | null,
+): string => {
+  switch (kind) {
+    case "utterance_heard":
+      return `FR2/F8: utterance captured.`;
+    case "intent_parsed":
+      return `FR2/F8: intent '${action ?? "unknown"}' parsed (confidence=${confidence?.toFixed(2) ?? "n/a"}).`;
+    case "intent_rejected":
+      return `FR2/F8: voice intent rejected (confidence=${confidence?.toFixed(2) ?? "n/a"}).`;
+    case "wake_word_missed":
+      return `FR2/F8: wake word missing — utterance ignored.`;
+  }
+};
+
+export interface VoiceEventInput {
+  action?: CommandAction | null;
+  confidence?: number | null;
+  transcript: string;
+  at?: Date;
+  message?: string;
+}
+
+export function createVoiceEvent(
+  kind: VoiceEventKind,
+  input: VoiceEventInput,
+): VoiceEvent {
+  const at = input.at ?? new Date();
+  const action = input.action ?? null;
+  const confidence = input.confidence ?? null;
+  return {
+    id: nextId(at),
+    kind,
+    action,
+    confidence,
+    transcript: input.transcript,
+    at,
+    message: input.message ?? baseMessage(kind, action, confidence),
+  };
+}

--- a/src/simulation/voiceIntent.ts
+++ b/src/simulation/voiceIntent.ts
@@ -1,0 +1,163 @@
+import type { CommandAction } from "@/types/whiteboard";
+
+/**
+ * F8 "use voice commands to prompt the eraser" — pure voice intent
+ * parser.
+ *
+ * Given a raw ASR transcript, normalize it (lowercase, strip
+ * punctuation, collapse whitespace) and match against a small,
+ * explicit phrase table. Returns a typed `VoiceIntent` with the
+ * matched `CommandAction` (or null) and a coarse confidence score
+ * derived from phrase specificity — the ASR layer can supply its own
+ * confidence separately via `ExternalVoiceIntent`.
+ *
+ * Pure — no audio, no `SpeechRecognition`, no React. Consumed by the
+ * FR2 command guard and by the audit pipeline.
+ */
+
+export const DEFAULT_VOICE_CONFIDENCE_MIN = 0.6;
+
+/** Default wake-word prefixes — callers may override per deployment. */
+export const DEFAULT_WAKE_WORDS: readonly string[] = [
+  "eraser",
+  "hey eraser",
+  "ok eraser",
+  "robot",
+];
+
+export interface VoiceIntent {
+  action: CommandAction | null;
+  confidence: number;
+  matchedPhrase: string | null;
+  wakeWord: string | null;
+  raw: string;
+  normalized: string;
+}
+
+interface PhraseEntry {
+  action: CommandAction;
+  phrases: readonly string[];
+  /** Base confidence before wake-word / length bonuses. */
+  baseConfidence: number;
+}
+
+/**
+ * Phrase table. Order matters only for test logging — matching runs
+ * across all entries and picks the highest-confidence result.
+ */
+const PHRASE_TABLE: readonly PhraseEntry[] = [
+  {
+    action: "start",
+    baseConfidence: 0.85,
+    phrases: [
+      "start erase",
+      "start erasing",
+      "erase the board",
+      "erase whiteboard",
+      "begin erase",
+      "go",
+    ],
+  },
+  {
+    action: "pause",
+    baseConfidence: 0.85,
+    phrases: ["pause", "pause erase", "pause erasing", "hold on", "wait"],
+  },
+  {
+    action: "stop",
+    baseConfidence: 0.9,
+    phrases: ["stop", "stop erase", "stop erasing", "cancel", "abort"],
+  },
+];
+
+const normalize = (text: string): string =>
+  text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const stripWakeWord = (
+  text: string,
+  wakeWords: readonly string[],
+): { remainder: string; wakeWord: string | null } => {
+  for (const w of wakeWords) {
+    const normalizedWake = normalize(w);
+    if (!normalizedWake) continue;
+    if (
+      text === normalizedWake ||
+      text.startsWith(`${normalizedWake} `)
+    ) {
+      return {
+        remainder: text.slice(normalizedWake.length).trim(),
+        wakeWord: w,
+      };
+    }
+  }
+  return { remainder: text, wakeWord: null };
+};
+
+export interface ParseVoiceIntentOptions {
+  wakeWords?: readonly string[];
+  /** ASR-supplied confidence (0..1) when available. Blended with phrase confidence. */
+  asrConfidence?: number;
+}
+
+export function parseVoiceIntent(
+  transcript: string,
+  options: ParseVoiceIntentOptions = {},
+): VoiceIntent {
+  const wakeWords = options.wakeWords ?? DEFAULT_WAKE_WORDS;
+  const raw = transcript ?? "";
+  const normalized = normalize(raw);
+  const { remainder, wakeWord } = stripWakeWord(normalized, wakeWords);
+
+  let best: {
+    entry: PhraseEntry;
+    phrase: string;
+    confidence: number;
+  } | null = null;
+
+  for (const entry of PHRASE_TABLE) {
+    for (const phrase of entry.phrases) {
+      const np = normalize(phrase);
+      if (!np) continue;
+      const matches = remainder === np || remainder.endsWith(` ${np}`) || remainder.startsWith(`${np} `) || remainder.includes(` ${np} `);
+      if (!matches) continue;
+      const wakeBonus = wakeWord ? 0.1 : 0;
+      const exactBonus = remainder === np ? 0.05 : 0;
+      const confidence = Math.min(
+        1,
+        entry.baseConfidence + wakeBonus + exactBonus,
+      );
+      if (!best || confidence > best.confidence) {
+        best = { entry, phrase, confidence };
+      }
+    }
+  }
+
+  if (!best) {
+    return {
+      action: null,
+      confidence: 0,
+      matchedPhrase: null,
+      wakeWord,
+      raw,
+      normalized,
+    };
+  }
+
+  const blended =
+    options.asrConfidence != null && Number.isFinite(options.asrConfidence)
+      ? Math.min(1, (best.confidence + Math.max(0, Math.min(1, options.asrConfidence))) / 2)
+      : best.confidence;
+
+  return {
+    action: best.entry.action,
+    confidence: blended,
+    matchedPhrase: best.phrase,
+    wakeWord,
+    raw,
+    normalized,
+  };
+}


### PR DESCRIPTION
Closes #71. Closes #222. Closes #223. Closes #224. Closes #225. Closes #226.

## Summary

Extends FR2 command control to cover **F8 — use voice commands to prompt the eraser** (#46). Adds a pure voice-intent pipeline so spoken commands are parsed into typed intents and validated by the same guard surface used by touch, schedule, and notification flows.

## Pipeline

```
transcript → parseVoiceIntent({ wakeWords, asrConfidence })
           → canStart / canPause / canStop({ source: "voice", voiceIntent, voiceConfidenceMin })
           → createVoiceEvent(kind, …)
```

## Changes

- **`src/simulation/voiceIntent.ts`** (new):
  - `parseVoiceIntent(transcript, options?)` → `VoiceIntent { action, confidence, matchedPhrase, wakeWord, raw, normalized }`.
  - Wake-word aware (`DEFAULT_WAKE_WORDS = ["eraser", "hey eraser", "ok eraser", "robot"]`), defensive normalization (lowercase, punctuation stripping, whitespace collapsing).
  - Phrase table covers `start` (e.g. "erase the board", "go"), `pause` ("hold on", "wait"), `stop` ("cancel", "abort"). Confidence blends a phrase base with a wake-word bonus, an exact-match bonus, and the ASR's own confidence if supplied.
  - `DEFAULT_VOICE_CONFIDENCE_MIN = 0.6`.
- **`src/simulation/voiceEvents.ts`** (new): typed `VoiceEventKind` factories (`utterance_heard`, `intent_parsed`, `intent_rejected`, `wake_word_missed`) mirroring `SafetyEvent` / `NotificationEvent`.
- **`src/simulation/commandGuards.ts`**:
  - `CommandSource` extended with `"voice"`.
  - `CommandContext` gains `voiceIntent` + `voiceConfidenceMin`.
  - New rejection codes `low_confidence` and `unrecognized_voice_command`.
  - Shared `voiceRejection` pre-check applied to `canStart`, `canPause`, `canStop`. Only triggers when `source === "voice"` — other sources are unaffected.
- **`src/simulation/index.ts`**: re-export every new symbol and type.

## Sub-task decomposition (traceability)

- 8.1.1 (#222) Pure `parseVoiceIntent` helper
- 8.1.2 (#223) Voice confidence threshold + rejection codes
- 8.1.3 (#224) `voice` `CommandSource` + guard wiring
- 8.1.4 (#225) Typed `VoiceEvent` audit factories
- 8.1.5 (#226) Document FR2 voice-command flow

## Verification

- `npx tsc --noEmit` clean.
- `npm run build` succeeds (only the pre-existing chunk-size notice).
- Fully backward compatible: existing call sites omit `voiceIntent`, so the voice check short-circuits immediately and F1 / F2 / F3 / F4 / F6 behavior is identical to before.
