### PR TITLE
Subissue 12.1 – FR4 Safety + Energy Compliance for F12 (#83)

### DIFF
--- a/src/simulation/complianceEvents.ts
+++ b/src/simulation/complianceEvents.ts
@@ -1,0 +1,72 @@
+import type { ComplianceFindingCode, ComplianceStatus } from "./safetyCompliance";
+
+/**
+ * F12 / FR4 compliance audit events. Typed factories for the audit
+ * trail, mirroring `SafetyEvent` / `NotificationEvent` / `VoiceEvent`.
+ * Pure; timestamps injectable for deterministic tests.
+ */
+
+export type ComplianceEventKind =
+  | "budget_exceeded"
+  | "duty_cycle_exceeded"
+  | "estop_verified"
+  | "compliance_pass"
+  | "compliance_warn"
+  | "compliance_fail";
+
+export interface ComplianceEvent {
+  id: string;
+  kind: ComplianceEventKind;
+  status: ComplianceStatus;
+  findingCode: ComplianceFindingCode | null;
+  at: Date;
+  message: string;
+  detail?: Record<string, number | string>;
+}
+
+let counter = 0;
+const nextId = (at: Date): string => {
+  counter = (counter + 1) % 1_000_000;
+  return `compliance-${at.getTime()}-${counter.toString(36)}`;
+};
+
+const baseMessage = (kind: ComplianceEventKind): string => {
+  switch (kind) {
+    case "budget_exceeded":
+      return "FR4/F12: energy budget exceeded.";
+    case "duty_cycle_exceeded":
+      return "FR4/F12: duty-cycle exceeded — cooling required.";
+    case "estop_verified":
+      return "FR4/F12: E-stop verified — Start permitted.";
+    case "compliance_pass":
+      return "FR4/F12: compliance check passed.";
+    case "compliance_warn":
+      return "FR4/F12: compliance warning.";
+    case "compliance_fail":
+      return "FR4/F12: compliance failed — operation blocked.";
+  }
+};
+
+export interface ComplianceEventInput {
+  status: ComplianceStatus;
+  findingCode?: ComplianceFindingCode | null;
+  at?: Date;
+  message?: string;
+  detail?: Record<string, number | string>;
+}
+
+export function createComplianceEvent(
+  kind: ComplianceEventKind,
+  input: ComplianceEventInput,
+): ComplianceEvent {
+  const at = input.at ?? new Date();
+  return {
+    id: nextId(at),
+    kind,
+    status: input.status,
+    findingCode: input.findingCode ?? null,
+    at,
+    message: input.message ?? baseMessage(kind),
+    detail: input.detail,
+  };
+}

--- a/src/simulation/dutyCycle.ts
+++ b/src/simulation/dutyCycle.ts
@@ -1,0 +1,85 @@
+/**
+ * F12 / FR4 — duty-cycle reducer.
+ *
+ * Tracks active-vs-idle time over a sliding window and flags when the
+ * active ratio exceeds the configured cap so the robot cools between
+ * erases and honors the thermal clause of the safety / energy
+ * standard.
+ *
+ * Pure reducer; caller supplies `now`. No timers, no DOM.
+ */
+
+export interface DutyCycleConfig {
+  /** Length of the evaluation window (ms). */
+  windowMs: number;
+  /** Max active / window (0..1). */
+  maxActiveRatio: number;
+}
+
+export const DEFAULT_DUTY_CYCLE: DutyCycleConfig = {
+  windowMs: 5 * 60_000,
+  maxActiveRatio: 0.5,
+};
+
+export interface DutyCycleSample {
+  active: boolean;
+  at: Date | number;
+}
+
+export interface DutyCycleState {
+  samples: readonly DutyCycleSample[];
+  activeMs: number;
+  windowMs: number;
+  ratio: number;
+  exceeded: boolean;
+}
+
+export const INITIAL_DUTY_CYCLE: DutyCycleState = {
+  samples: [],
+  activeMs: 0,
+  windowMs: 0,
+  ratio: 0,
+  exceeded: false,
+};
+
+const toMs = (t: Date | number): number => (t instanceof Date ? t.getTime() : t);
+
+/**
+ * Append a sample and evict samples outside the window. Returns the
+ * next state (immutable). `ratio` is active_ms / actual_window_ms.
+ */
+export function reduceDutyCycle(
+  state: DutyCycleState,
+  sample: DutyCycleSample,
+  config: DutyCycleConfig = DEFAULT_DUTY_CYCLE,
+): DutyCycleState {
+  const nowMs = toMs(sample.at);
+  const windowStart = nowMs - Math.max(1, config.windowMs);
+
+  const kept: DutyCycleSample[] = [];
+  for (const s of state.samples) {
+    if (toMs(s.at) >= windowStart) kept.push(s);
+  }
+  kept.push(sample);
+
+  let activeMs = 0;
+  for (let i = 0; i < kept.length - 1; i += 1) {
+    const a = kept[i];
+    const b = kept[i + 1];
+    const dt = toMs(b.at) - toMs(a.at);
+    if (dt > 0 && a.active) activeMs += dt;
+  }
+
+  const first = toMs(kept[0].at);
+  const last = toMs(kept[kept.length - 1].at);
+  const actualWindowMs = Math.max(1, last - first);
+  const ratio = activeMs / actualWindowMs;
+
+  return {
+    samples: kept,
+    activeMs,
+    windowMs: actualWindowMs,
+    ratio,
+    exceeded: ratio > config.maxActiveRatio,
+  };
+}

--- a/src/simulation/energyBudget.ts
+++ b/src/simulation/energyBudget.ts
@@ -1,0 +1,63 @@
+/**
+ * F12 / FR4 — energy budget validator.
+ *
+ * Pure check that a power sample (instantaneous W, average W, peak W)
+ * satisfies a configured budget, consistent with the safety / energy
+ * standards clause (draw caps for motors + compute + sensors).
+ *
+ * Returns a discriminated union so the compliance aggregator can cite
+ * the specific failure mode without string matching.
+ */
+
+export interface EnergyBudget {
+  /** Hard ceiling on instantaneous power (W). */
+  maxInstantW: number;
+  /** Ceiling on sliding average power (W). */
+  maxAverageW: number;
+  /** Ceiling on observed peak (W). */
+  maxPeakW: number;
+}
+
+export const DEFAULT_ENERGY_BUDGET: EnergyBudget = {
+  maxInstantW: 150,
+  maxAverageW: 80,
+  maxPeakW: 180,
+};
+
+export interface EnergySample {
+  instantW: number;
+  averageW: number;
+  peakW: number;
+  at?: Date;
+}
+
+export type EnergyCheckReason =
+  | "instant_exceeded"
+  | "average_exceeded"
+  | "peak_exceeded"
+  | "invalid_sample";
+
+export type EnergyCheck =
+  | { ok: true; sample: EnergySample }
+  | { ok: false; reason: EnergyCheckReason; sample: EnergySample; limitW: number };
+
+const finite = (n: number): boolean => Number.isFinite(n);
+
+export function checkEnergyBudget(
+  sample: EnergySample,
+  budget: EnergyBudget = DEFAULT_ENERGY_BUDGET,
+): EnergyCheck {
+  if (!finite(sample.instantW) || !finite(sample.averageW) || !finite(sample.peakW)) {
+    return { ok: false, reason: "invalid_sample", sample, limitW: 0 };
+  }
+  if (sample.instantW > budget.maxInstantW) {
+    return { ok: false, reason: "instant_exceeded", sample, limitW: budget.maxInstantW };
+  }
+  if (sample.averageW > budget.maxAverageW) {
+    return { ok: false, reason: "average_exceeded", sample, limitW: budget.maxAverageW };
+  }
+  if (sample.peakW > budget.maxPeakW) {
+    return { ok: false, reason: "peak_exceeded", sample, limitW: budget.maxPeakW };
+  }
+  return { ok: true, sample };
+}

--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -92,6 +92,41 @@ export type {
   VoiceEventInput,
   VoiceEventKind,
 } from "./voiceEvents";
+export {
+  DEFAULT_ENERGY_BUDGET,
+  checkEnergyBudget,
+} from "./energyBudget";
+export type {
+  EnergyBudget,
+  EnergyCheck,
+  EnergyCheckReason,
+  EnergySample,
+} from "./energyBudget";
+export {
+  DEFAULT_DUTY_CYCLE,
+  INITIAL_DUTY_CYCLE,
+  reduceDutyCycle,
+} from "./dutyCycle";
+export type {
+  DutyCycleConfig,
+  DutyCycleSample,
+  DutyCycleState,
+} from "./dutyCycle";
+export { evaluateCompliance } from "./safetyCompliance";
+export type {
+  ComplianceFinding,
+  ComplianceFindingCode,
+  ComplianceInput,
+  ComplianceReport,
+  ComplianceSeverity,
+  ComplianceStatus,
+} from "./safetyCompliance";
+export { createComplianceEvent } from "./complianceEvents";
+export type {
+  ComplianceEvent,
+  ComplianceEventInput,
+  ComplianceEventKind,
+} from "./complianceEvents";
 export { validateEraseArea } from "./validateEraseArea";
 export type {
   CanvasBounds,

--- a/src/simulation/safetyCompliance.ts
+++ b/src/simulation/safetyCompliance.ts
@@ -1,0 +1,122 @@
+import type { ProximityZone } from "./proximityClassifier";
+import {
+  checkEnergyBudget,
+  type EnergyBudget,
+  type EnergySample,
+} from "./energyBudget";
+import type { DutyCycleState } from "./dutyCycle";
+
+/**
+ * F12 / FR4 — safety + energy compliance aggregator.
+ *
+ * Composes the three independent signals (proximity zone, energy
+ * budget check, duty-cycle reducer output) into a single typed
+ * `ComplianceReport`. Single decision surface FR4 can cite when
+ * refusing to Start a trajectory or halting mid-run.
+ *
+ * Pure — no timers, no DOM, no external state.
+ */
+
+export type ComplianceFindingCode =
+  | "proximity_danger"
+  | "proximity_warning"
+  | "energy_instant_exceeded"
+  | "energy_average_exceeded"
+  | "energy_peak_exceeded"
+  | "energy_invalid_sample"
+  | "duty_cycle_exceeded"
+  | "estop_not_verified";
+
+export type ComplianceSeverity = "info" | "warn" | "fail";
+
+export interface ComplianceFinding {
+  code: ComplianceFindingCode;
+  severity: ComplianceSeverity;
+  message: string;
+  detail?: Record<string, number | string>;
+}
+
+export type ComplianceStatus = "pass" | "warn" | "fail";
+
+export interface ComplianceReport {
+  status: ComplianceStatus;
+  findings: readonly ComplianceFinding[];
+}
+
+export interface ComplianceInput {
+  proximityZone: ProximityZone;
+  energy?: { sample: EnergySample; budget?: EnergyBudget };
+  duty?: DutyCycleState;
+  estopVerified?: boolean;
+}
+
+const highestSeverity = (findings: readonly ComplianceFinding[]): ComplianceStatus => {
+  let status: ComplianceStatus = "pass";
+  for (const f of findings) {
+    if (f.severity === "fail") return "fail";
+    if (f.severity === "warn") status = "warn";
+  }
+  return status;
+};
+
+export function evaluateCompliance(input: ComplianceInput): ComplianceReport {
+  const findings: ComplianceFinding[] = [];
+
+  if (input.proximityZone === "danger") {
+    findings.push({
+      code: "proximity_danger",
+      severity: "fail",
+      message: "FR4: student in danger zone — robot must not operate.",
+    });
+  } else if (input.proximityZone === "warning") {
+    findings.push({
+      code: "proximity_warning",
+      severity: "warn",
+      message: "FR4: student in warning zone — proceed with caution.",
+    });
+  }
+
+  if (input.energy) {
+    const check = checkEnergyBudget(input.energy.sample, input.energy.budget);
+    if (!check.ok) {
+      const severity: ComplianceSeverity =
+        check.reason === "invalid_sample" ? "warn" : "fail";
+      const code: ComplianceFindingCode =
+        check.reason === "instant_exceeded"
+          ? "energy_instant_exceeded"
+          : check.reason === "average_exceeded"
+            ? "energy_average_exceeded"
+            : check.reason === "peak_exceeded"
+              ? "energy_peak_exceeded"
+              : "energy_invalid_sample";
+      findings.push({
+        code,
+        severity,
+        message: `FR4/F12: energy budget violated (${check.reason.replace(/_/g, " ")}).`,
+        detail: { limitW: check.limitW },
+      });
+    }
+  }
+
+  if (input.duty?.exceeded) {
+    findings.push({
+      code: "duty_cycle_exceeded",
+      severity: "fail",
+      message: "FR4/F12: duty-cycle exceeded — robot must cool before next run.",
+      detail: { ratio: Number(input.duty.ratio.toFixed(3)) },
+    });
+  }
+
+  if (input.estopVerified === false) {
+    findings.push({
+      code: "estop_not_verified",
+      severity: "fail",
+      message: "FR4/F12: E-stop verification missing — refuse to Start.",
+    });
+  }
+
+  return {
+    status: highestSeverity(findings),
+    findings,
+  };
+}


### PR DESCRIPTION
Closes #83. Closes #228. Closes #229. Closes #230. Closes #231. Closes #232.

## Summary

Extends FR4 safety + proximity coverage to the **F12 — ensure system meets safety and energy standards** (#50) clause. Today's safety surface only knows about proximity; this PR adds energy budget, duty-cycle, and E-stop verification, then composes all four signals through a single `evaluateCompliance` aggregator so the React bridge and the robot runner share one decision point.

## Pipeline

```
instant / average / peak W  →  checkEnergyBudget
sliding active/idle samples →  reduceDutyCycle
proximity zone              →  (from safetyPolicy)
E-stop verification         →  estopVerified flag
                           ↓
              evaluateCompliance({ … })
                           ↓
           ComplianceReport { status, findings[] }
                           ↓
            createComplianceEvent(kind, …)
```

## Changes

- **`src/simulation/energyBudget.ts`** (new):
  - `EnergyBudget` with caps on instant / average / peak W.
  - `checkEnergyBudget(sample, budget?)` returning a discriminated union naming the specific violation (`instant_exceeded`, `average_exceeded`, `peak_exceeded`, `invalid_sample`).
  - `DEFAULT_ENERGY_BUDGET = { maxInstantW: 150, maxAverageW: 80, maxPeakW: 180 }`.
- **`src/simulation/dutyCycle.ts`** (new):
  - `reduceDutyCycle(state, sample, config?)` pure sliding-window reducer evicting samples outside `windowMs`, summing active intervals, reporting `ratio` and `exceeded`.
  - `DEFAULT_DUTY_CYCLE = { windowMs: 5 min, maxActiveRatio: 0.5 }`.
- **`src/simulation/safetyCompliance.ts`** (new):
  - `evaluateCompliance({ proximityZone, energy, duty, estopVerified })` → `ComplianceReport { status: pass | warn | fail, findings }`.
  - Typed `ComplianceFindingCode` (`proximity_danger`, `proximity_warning`, `energy_*`, `duty_cycle_exceeded`, `estop_not_verified`).
- **`src/simulation/complianceEvents.ts`** (new): typed `ComplianceEventKind` factories (`budget_exceeded`, `duty_cycle_exceeded`, `estop_verified`, `compliance_pass`, `compliance_warn`, `compliance_fail`) mirroring `SafetyEvent` / `NotificationEvent` / `VoiceEvent`.
- **`src/simulation/index.ts`**: re-export every new symbol and type.

All modules are pure — no React, no DOM, no timers — directly reusable by the Python robot bridge later.

## Sub-task decomposition (traceability)

- 12.1.1 (#228) Energy budget validator
- 12.1.2 (#229) Duty-cycle reducer
- 12.1.3 (#230) Safety / energy compliance aggregator
- 12.1.4 (#231) Typed `ComplianceEvent` audit factories
- 12.1.5 (#232) Document FR4 compliance pipeline

## Verification

- `npx tsc --noEmit` clean.
- `npm run build` succeeds (only the pre-existing chunk-size notice).
- Zero changes to existing call sites; the aggregator opts in via `evaluateCompliance(input)` and existing FR4 proximity behavior is unaffected. Hook / UI wiring deferred to sister subissues 12.2 / 12.3.
