### PR TITLE
R1 – AI verification checklist for safety/timing-sensitive changes (#93)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+<!--
+Thanks for the PR. Fill in every section.
+Safety / timing / Story-6 changes MUST run the AI Verification Checklist
+(docs/AI_VERIFICATION_CHECKLIST.md). See Risk Task R1 (#93).
+-->
+
+## Summary
+
+<!-- 1–3 sentences on what changed and why. -->
+
+## Linked issues
+
+<!-- e.g. Closes #NN — parent feature or risk task. -->
+
+## AI disclosure (R1 — #93)
+
+- [ ] No AI-generated edits in this PR.
+- [ ] AI-generated edits present. Sections + tool:
+  - `path/to/file.ts` lines `XX–YY` — tool: `...`
+- [ ] No machine-generated `Co-authored-by` / `Made-with` / `Generated-by`
+  trailers in commits or PR body.
+
+## Scope triage (R1 — §1 of the checklist)
+
+Tick every area the diff touches. If any is ticked, the **AI
+Verification Checklist** (`docs/AI_VERIFICATION_CHECKLIST.md`) must be
+completed inline below or linked from a review comment.
+
+- [ ] FR4 — safety / proximity (`simulation/proximity*`, `safety*`, `compliance*`, `energyBudget.ts`, `dutyCycle.ts`, `robot/erase_whiteboard.py` motion paths)
+- [ ] NFR1 — responsiveness / timing (`touchRateLimit.ts`, `eraseSchedule.ts`, `eraseNotification.ts`, new `setTimeout`/`setInterval`)
+- [ ] Story 6 — pre-erase notification (`eraseNotification.ts`, `notificationEvents.ts`, notification UI)
+- [ ] Command guards / voice intent (`commandGuards.ts`, `voiceIntent.ts`, `voiceEvents.ts`)
+- [ ] None of the above — R1 does not trigger.
+
+## Verification
+
+- [ ] `npx tsc --noEmit` clean
+- [ ] `npm run build` succeeds
+- [ ] Manual check or test evidence (describe):
+
+## Reviewer sign-off (R1 — §7)
+
+- [ ] Author completed §1–§6 of the checklist.
+- [ ] Reviewer re-verified §3 (safety invariants).
+- [ ] Reviewer re-verified §4 (timing invariants).
+- [ ] Reviewer re-verified §5 if Story 6 was ticked.

--- a/docs/AI_VERIFICATION_CHECKLIST.md
+++ b/docs/AI_VERIFICATION_CHECKLIST.md
@@ -1,0 +1,117 @@
+# AI Verification Checklist — Safety- and Timing-Sensitive Changes
+
+> **Risk task R1 (#93).** Mandatory review gate for any pull request that
+> contains AI-generated edits touching **NFR1 (responsiveness / timing)**,
+> **FR4 (safety and proximity)**, or **Story 6 (pre-erase notification)**
+> behavior. The author and at least one human reviewer must both complete
+> this checklist before merge.
+
+---
+
+## 1. Scope triage — does this PR trigger R1?
+
+Tick **Yes** if the diff touches any of the files or directories in each
+row. If every answer is **No**, skip to §6 and record the PR as
+"non-triggering".
+
+| Area | Representative paths | Triggered? |
+|---|---|---|
+| **FR4 — safety / proximity** | `src/simulation/proximity*`, `src/simulation/safety*`, `src/simulation/compliance*`, `src/simulation/energyBudget.ts`, `src/simulation/dutyCycle.ts`, `robot/erase_whiteboard.py` (motion / E-stop paths) | ☐ |
+| **NFR1 — responsiveness / timing** | `src/simulation/touchRateLimit.ts`, `src/simulation/eraseSchedule.ts`, `src/simulation/eraseNotification.ts`, any `setTimeout` / `setInterval` / `requestAnimationFrame` / debounce / throttle, Python `time.sleep` on the control loop | ☐ |
+| **Story 6 — pre-erase notification** | `src/simulation/eraseNotification.ts`, `src/simulation/notificationEvents.ts`, `src/components/**/Notification*`, countdown / acknowledgment UI | ☐ |
+| **Command guards / voice intent** (indirect FR4) | `src/simulation/commandGuards.ts`, `src/simulation/voiceIntent.ts`, `src/simulation/voiceEvents.ts` | ☐ |
+
+If **any** row is ticked, all sections below are mandatory.
+
+---
+
+## 2. AI attribution disclosure
+
+- [ ] The PR description names **which** sections of the diff were
+  AI-generated (file list or line ranges) and **which** tool produced them.
+- [ ] No machine-generated `Co-authored-by` / `Made-with` / `Generated-by`
+  trailers appear in commits or PR body (project policy).
+- [ ] Every AI-generated hunk has been **read line-by-line** by the
+  author, not merely skimmed. The author is prepared to defend every line.
+
+## 3. Safety invariants (FR4)
+
+Confirm each invariant still holds after the diff. Link the file + line
+that proves it if the diff is large.
+
+- [ ] E-stop path cannot be shadowed: `estopVerified === false` still
+  produces `status: "fail"` in `evaluateCompliance`.
+- [ ] Proximity `danger` still forces `safetyPolicy` to `halt` regardless
+  of upstream status.
+- [ ] Proximity hysteresis thresholds are unchanged, or if changed, the
+  new values are justified in the PR body and matched in the tests.
+- [ ] Energy budget caps (`DEFAULT_ENERGY_BUDGET`) are unchanged, or the
+  change is accompanied by a safety rationale citing the robot datasheet.
+- [ ] Duty-cycle cap (`DEFAULT_DUTY_CYCLE.maxActiveRatio`) is unchanged,
+  or the change is justified by thermal evidence.
+- [ ] No new path reaches `runCartesianTrajectory` / motion commands
+  without first passing a command guard.
+
+## 4. Timing invariants (NFR1)
+
+- [ ] Touch rate-limit minimum interval (`DEFAULT_TOUCH_MIN_INTERVAL_MS`)
+  is unchanged, or the change is documented.
+- [ ] Countdown durations (`DEFAULT_PRE_WARN_MS`, `DEFAULT_COUNTDOWN_MS`,
+  `DEFAULT_FINAL_MS`) are unchanged, or the change is documented.
+- [ ] No blocking `await` was added to a UI render path or a 50 ms
+  control loop tick.
+- [ ] No new `setInterval` without a matching teardown in the same
+  effect / lifecycle scope.
+- [ ] Any new timer uses injectable `now` / `Date` so tests remain
+  deterministic (consistent with existing `simulation/*` modules).
+
+## 5. Story 6 — pre-erase notification invariants
+
+- [ ] `CommandContext.requireAcknowledgment === true` still blocks
+  `canStart` when `acknowledgedAt` is null
+  (`commandGuards.ts` → rejection `notification_not_acknowledged`).
+- [ ] Countdown phases (`pre_warn → countdown → final → go → canceled`)
+  cannot be skipped except via an explicit `stopErase`.
+- [ ] Acknowledgment events (`createNotificationEvent`) are emitted for
+  every shown / acknowledged / canceled transition.
+
+## 6. Verification evidence
+
+Paste or link evidence into the PR body.
+
+- [ ] `npx tsc --noEmit` — no errors.
+- [ ] `npm run build` — succeeds.
+- [ ] `npm run lint` (if configured) — no new warnings.
+- [ ] Unit / integration tests run and pass on a triggered area, or the
+  author states explicitly that no test suite covers the change and
+  files a follow-up issue.
+- [ ] For FR4 changes: a manual dry-run on the robot in `--verify` mode
+  (no motion) is described, or the PR is labeled **ui-only** and the
+  author states the robot was not exercised.
+
+## 7. Reviewer sign-off
+
+- [ ] **Author**: I have completed §1–§6 and disclosed all AI-generated
+  sections.
+- [ ] **Reviewer**: I independently re-verified §3 (safety invariants)
+  against the diff.
+- [ ] **Reviewer**: I independently re-verified §4 (timing invariants)
+  against the diff.
+- [ ] **Reviewer**: If §1 Story 6 is ticked, I verified §5.
+
+---
+
+## Appendix A — Why this checklist exists
+
+AI-generated edits are fast but can silently invert a guard clause,
+drop an acknowledgment branch, or rescale a timing constant. Whiteboard
+eraser safety depends on small numeric constants and early-return
+patterns that diff tools do not highlight as risky. This checklist
+forces both the author and a human reviewer to re-read those specific
+paths before merge.
+
+## Appendix B — Escalation
+
+If §3 or §5 cannot be confirmed, **do not merge**. Open a blocking
+follow-up issue referencing #93 and re-request review after the
+invariant is restored.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,4 +8,5 @@
 | [LAB5_SPRINT_EXECUTION_SUMMARY.md](./LAB5_SPRINT_EXECUTION_SUMMARY.md) | Lab 5 — sprint execution summary (completed/incomplete, collaboration, evidence) |
 | [RTM_LAB5_UPDATE.md](./RTM_LAB5_UPDATE.md) | Lab 5 — updated traceability matrix for sprint execution |
 | [LAB6_LOVABLE_FEATURE_EXTENSION.md](./LAB6_LOVABLE_FEATURE_EXTENSION.md) | Lab 6 — Lovable.dev feature extension (PR documentation, Subissue 2.3 / FR5) |
+| [AI_VERIFICATION_CHECKLIST.md](./AI_VERIFICATION_CHECKLIST.md) | Risk R1 — mandatory review checklist for AI-generated edits affecting NFR1 / FR4 / Story 6 |
 | [architecture-diagram.svg](./architecture-diagram.svg) | Architecture diagram (referenced by the project reset report) |


### PR DESCRIPTION
Closes #93.

## Summary

Risk Task **R1** — formalizes a mandatory review gate for AI-generated edits affecting **NFR1 (responsiveness / timing)**, **FR4 (safety and proximity)**, or **Story 6 (pre-erase notification)** behavior. Both the author and a reviewer must complete the checklist before merge.

## What ships

- **`docs/AI_VERIFICATION_CHECKLIST.md`** — seven-section checklist:
  1. **Scope triage** — file-path table that decides whether R1 triggers.
  2. **AI attribution disclosure** — which hunks are AI-generated and by which tool; prohibits `Co-authored-by` / `Made-with` / `Generated-by` trailers per project policy.
  3. **Safety invariants (FR4)** — E-stop cannot be shadowed, `proximity: danger ⇒ halt`, hysteresis thresholds unchanged, `DEFAULT_ENERGY_BUDGET` / `DEFAULT_DUTY_CYCLE` unchanged, no motion path bypasses a command guard.
  4. **Timing invariants (NFR1)** — `DEFAULT_TOUCH_MIN_INTERVAL_MS` and the countdown constants unchanged, no blocking `await` on render / 50 ms control tick, no leaked `setInterval`, injectable `now`.
  5. **Story 6 invariants** — `requireAcknowledgment` still blocks `canStart`, countdown phases cannot be skipped, acknowledgment events are emitted.
  6. **Verification evidence** — `tsc --noEmit`, `npm run build`, tests, robot `--verify` dry-run.
  7. **Reviewer sign-off** — independent re-verification of §3 / §4 / §5 by a human reviewer.
- **`.github/pull_request_template.md`** — enforces the checklist at PR-open time. Every new PR now surfaces the triage table, the AI disclosure block, and the reviewer sign-off.
- **`docs/README.md`** — links the checklist from the docs index.

## Why this exists

AI-generated edits are fast but can silently invert a guard clause, drop an acknowledgment branch, or rescale a timing constant. Whiteboard-eraser safety depends on small numeric constants and early-return patterns that diff tools do not highlight as risky. The checklist forces both author and reviewer to re-read those specific paths before merge.

## Verification

- Docs-only change; no code paths touched.
- Triage table references real paths that exist on `main` (`src/simulation/proximity*`, `safety*`, `compliance*`, `energyBudget.ts`, `dutyCycle.ts`, `touchRateLimit.ts`, `eraseSchedule.ts`, `eraseNotification.ts`, `commandGuards.ts`, `voiceIntent.ts`).
- PR template will appear on the next PR opened after merge.
